### PR TITLE
Handle level 70 Wrath transition

### DIFF
--- a/LevelingTracker.lua
+++ b/LevelingTracker.lua
@@ -115,6 +115,21 @@ function addon.tracker:UpgradeDB()
             end
         end
     end
+
+    -- On 60/70 login, set timestamp.started to now
+    -- aka ignore raiding time against 60-61 and 70-71
+    -- Also support fresh Wrath users of RXP
+    if UnitXP("player") == 0 and self.playerLevel == 70 and self.maxLevel >
+        self.playerLevel then
+
+        if levelDB[self.playerLevel].timestamp then
+            levelDB[self.playerLevel].timestamp.started = time()
+        else
+            levelDB[self.playerLevel].timestamp = {started = time()}
+        end
+        addon.comms.PrettyPrint("Resetting level %d start time to now!",
+                                self.playerLevel)
+    end
 end
 
 function addon.tracker:GenerateDBLevel(level)


### PR DESCRIPTION
- [x] Reset `timestamp.started` on first 70 Wrath login