### PR TITLE
Update level splits parsing logic

### DIFF
--- a/LevelingTracker.lua
+++ b/LevelingTracker.lua
@@ -1103,7 +1103,7 @@ function addon.tracker:UpdateLevelSplits(kind)
                 if splitsString then
                     splitsString = fmt("%s\n%s", splitsString, data.text)
                 else
-                    splitsString = fmt("%s", data.text)
+                    splitsString = data.text
                 end
             end
         end


### PR DESCRIPTION
* Always starts counter from lowest level now, rather than what was shown
* Prepare for inspection and comparison, by moving data to objects