### PR TITLE
Added a button to reset the arrow position

### DIFF
--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -931,7 +931,7 @@ function addon.settings:CreateAceOptionsPanel()
                         order = 5.4,
                         name = L("Reset Arrow Position"), -- TODO locale
                         type = "execute",
-                        width = "small",
+                        width = optionsWidth,
                         func = function()
                             addon.ResetArrowPosition()
                         end

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -927,6 +927,15 @@ function addon.settings:CreateAceOptionsPanel()
                                                           "OUTLINE")
                         end
                     },
+                    resetArrowPosition = {
+                        order = 5.4,
+                        name = L("Reset Arrow Position"), -- TODO locale
+                        type = "execute",
+                        width = "small",
+                        func = function()
+                            addon.ResetArrowPosition()
+                        end
+                    },
                     macroHeader = {
                         name = L("Targeting Macro"), -- TODO locale
                         type = "header",

--- a/map.lua
+++ b/map.lua
@@ -42,6 +42,11 @@ af:SetScript("OnMouseDown", function(self, button)
 end)
 af:SetScript("OnMouseUp", function(self, button) af:StopMovingOrSizing() end)
 
+function addon.ResetArrowPosition()
+    af:ClearAllPoints()
+    af:SetPoint("CENTER", af:GetParent(), "CENTER", 0, 0)
+end
+
 function addon.UpdateArrow(self)
 
     if addon.settings.db.profile.disableArrow or not self then return end

--- a/map.lua
+++ b/map.lua
@@ -44,7 +44,7 @@ af:SetScript("OnMouseUp", function(self, button) af:StopMovingOrSizing() end)
 
 function addon.ResetArrowPosition()
     af:ClearAllPoints()
-    af:SetPoint("CENTER", af:GetParent(), "CENTER", 0, 0)
+    af:SetPoint("CENTER", 0, 200)
 end
 
 function addon.UpdateArrow(self)


### PR DESCRIPTION
Changes:
- Added a button to reset the position of the nav arrow to the center of the screen.


We could also move this to top of screen since thats where it defaults to