### PR TITLE
Remove timer bar cache.

### DIFF
--- a/Timers.lua
+++ b/Timers.lua
@@ -9,74 +9,16 @@ RXPFrame.BarContainer = BarContainer
 BarContainer.barTexture = "Interface\\CHARACTERFRAME\\BarFill"
 BarContainer.barIcon = "Interface\\ICONS\\INV_Misc_PocketWatch_02"
 
-BarContainer.barPool = {}
-BarContainer.labels = {}
-
-
 BarContainer:ClearAllPoints()
 BarContainer:SetPoint("TOPLEFT",RXPFrame.Footer,"TOPLEFT",4,0)
 BarContainer:SetPoint("BOTTOMRIGHT",RXPFrame.Footer,"BOTTOMRIGHT",0,1)
 
-function BarContainer.SetAnchor()
-    local anchor = RXPFrame.CurrentStepFrame.anchor
-    --print(anchor)
-    local lastActive
-    local nBars = -1
-    local spacing = 0
-    for i,bar in ipairs(BarContainer.barPool) do
-        if bar:IsShown() then
-            if lastActive and anchor == "BOTTOM" then
-                bar:SetAlpha(0)
-            else
-                bar:SetAlpha(1)
-            end
-            spacing = -(BarContainer.height+2)*nBars
-            bar:ClearAllPoints()
-            bar:SetPoint("TOPLEFT",BarContainer,"BOTTOMLEFT",0,spacing)
-            bar:SetPoint("TOPRIGHT",BarContainer,"BOTTOMRIGHT",0,spacing)
-            nBars = nBars + 1
-            lastActive = bar
-            --print(i,spacing)
-        end
-    end
-    if not lastActive then
-        RXPFrame.Footer.icon:SetAlpha(1)
-        RXPFrame.Footer.text:SetAlpha(1)
-        RXPFrame.Footer.cog:SetAlpha(1)
-    end
-    BarContainer:SetHeight(spacing+BarContainer.height)
-end
 
-function BarContainer:Acquire(label)
-    local bar
-    for i = #BarContainer.barPool,1,-1 do
-        local v = BarContainer.barPool[i]
-        if label and BarContainer.labels[v] == label then
-            bar = v
-            break
-        elseif not v:IsShown() then
-            bar = v
-        end
-    end
-    if bar then
-        BarContainer.labels[bar] = label
-        bar:SetLabel(label)
-        bar:SetIcon(BarContainer.barIcon)
-        bar:SetColor(unpack(addon.colors.mapPins))
-        bar:SetTexture(BarContainer.barTexture)
-        return bar
-    end
-    return BarContainer:CreateBar(label)
-end
-
-function BarContainer:CreateBar(label)
+local function CreateBar(label)
     local bar = candy:New(BarContainer.barTexture, 100, 16)
     bar:SetDuration(60)
     bar:SetPoint("TOPLEFT",BarContainer,"TOPLEFT")
     bar:SetPoint("TOPRIGHT",BarContainer,"TOPRIGHT")
-    bar:SetScript("OnHide",BarContainer.SetAnchor)
-    table.insert(BarContainer.barPool,bar)
-    BarContainer.labels[bar] = label
     bar:SetIcon(BarContainer.barIcon)
     bar:SetColor(unpack(addon.colors.mapPins))
     bar:SetLabel(label)
@@ -85,7 +27,7 @@ end
 --RXP = addon
 function addon.StartTimer(duration,label,options)
     if type(duration) ~= "number" or duration <= 0 or not RXPFrame:IsShown() then return end
-    local bar = RXPFrame.BarContainer:Acquire(label or "")
+    local bar = CreateBar(label or "")
     bar:SetDuration(duration)
     if options then
         if options.colors then
@@ -99,7 +41,6 @@ function addon.StartTimer(duration,label,options)
         end
     end
     bar:Start()
-    BarContainer.SetAnchor()
     RXPFrame.Footer.icon:SetAlpha(0)
     RXPFrame.Footer.text:SetAlpha(0)
     RXPFrame.Footer.cog:SetAlpha(0)


### PR DESCRIPTION
LibCandyBar-3.0 has its own internal cache, and keeping a cache outside of that causes conflicts with other addons (e.g. Leatrix's flight timer).