### PR TITLE
Add text color config

### DIFF
--- a/GuideWindow.lua
+++ b/GuideWindow.lua
@@ -626,6 +626,7 @@ function addon.SetStep(n, n2, loopback)
                 elementFrame.text:SetJustifyV("MIDDLE")
                 elementFrame.text:SetTextColor(
                     unpack(addon.activeTheme.textColor))
+
                 elementFrame.text:SetFont(addon.font, addon.settings.db.profile
                                               .guideFontSize + 2, "") -- 11
 
@@ -837,8 +838,7 @@ function CurrentStepFrame.UpdateText()
                     elementFrame.text:SetPoint("TOPLEFT", elementFrame.button,
                                                "TOPRIGHT", 11, -1)
                     elementFrame.text:SetPoint("RIGHT", stepframe, -5, 0)
-
-                    text:SetText(L(element.text))
+                    text:SetText(addon.settings:ReplaceColors(L(element.text)))
                     local h = math.ceil(elementFrame.text:GetStringHeight() *
                                             1.1) + 1
                     -- print('sh:',h)

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -2546,10 +2546,7 @@ function addon.settings:DisableTextColors()
 end
 
 function addon.settings:ReplaceColors(textLine)
-    -- TODO handle nil lookups
-
     -- Replace text placeholders
-    -- TODO handle RXP_FOO_ActualThing
     for RXP_ in string.gmatch(textLine, "RXP_[A-Z]+_") do
         textLine = textLine:gsub(RXP_, addon.guideTextColors[RXP_] or
                                      addon.guideTextColors.default["error"])

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -31,6 +31,8 @@ if not addon.settings.gui then
     addon.settings.gui = {selectedDeleteGuide = "", importStatusHistory = {}}
 end
 
+local settingsCache = {}
+
 function addon.settings.ChatCommand(input)
     if not input then
         _G.InterfaceOptionsFrame_OpenToCategory(addon.RXPOptions)
@@ -136,12 +138,12 @@ function addon.settings:InitializeSettings()
             enableThemeLiveReload = true,
 
             -- Text colors
-            textEnemyColor = addon.guideTextColors['RXP_ENEMY'],
-            textFriendlyColor = addon.guideTextColors['RXP_FRIENDLY'],
-            textLootColor = addon.guideTextColors['RXP_LOOTY'],
-            textWarnColor = addon.guideTextColors['RXP_WARN'],
-            textPickColor = addon.guideTextColors['RXP_PICK'],
-            textBuyColor = addon.guideTextColors['RXP_BUY']
+            textEnemyColor = addon.guideTextColors.default['RXP_ENEMY'],
+            textFriendlyColor = addon.guideTextColors.default['RXP_FRIENDLY'],
+            textLootColor = addon.guideTextColors.default['RXP_LOOT'],
+            textWarnColor = addon.guideTextColors.default['RXP_WARN'],
+            textPickColor = addon.guideTextColors.default['RXP_PICK'],
+            textBuyColor = addon.guideTextColors.default['RXP_BUY']
         }
     }
 
@@ -154,6 +156,7 @@ function addon.settings:InitializeSettings()
     self:CreateAceOptionsPanel()
     self:CreateImportOptionsPanel()
     self:MigrateSettings()
+    self:LoadTextColors()
 
     self:RegisterChatCommand("rxp", self.ChatCommand)
     self:RegisterChatCommand("rxpg", self.ChatCommand)
@@ -1840,11 +1843,15 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 2.1,
                         get = function()
+                            print("textEnemyColor",
+                                  self.db.profile.textEnemyColor)
                             return self:HexToRGB(self.db.profile.textEnemyColor)
                         end,
-                        set = function(_, r, g, b)
-                            self.db.profile.textEnemyColor = self:RGBToHex(r, g,
-                                                                           b)
+                        set = function(_, r, g, b, a)
+                            self.db.profile.textEnemyColor = self:RGBToString(r,
+                                                                              g,
+                                                                              b,
+                                                                              a)
                         end
                     },
                     textFriendlyColor = {
@@ -1854,13 +1861,13 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 2.2,
                         get = function()
+                            -- print("textFriendlyColor", self.db.profile.textFriendlyColor)
                             return self:HexToRGB(self.db.profile
                                                      .textFriendlyColor)
                         end,
-                        set = function(_, r, g, b)
-                            self.db.profile.textFriendlyColor = self:RGBToHex(r,
-                                                                              g,
-                                                                              b)
+                        set = function(_, r, g, b, a)
+                            self.db.profile.textFriendlyColor =
+                                self:RGBToString(r, g, b, a)
                         end
                     },
                     textLootColor = {
@@ -1870,11 +1877,14 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 2.3,
                         get = function()
+                            -- print("textLootColor", self.db.profile.textLootColor)
                             return self:HexToRGB(self.db.profile.textLootColor)
                         end,
-                        set = function(_, r, g, b)
-                            self.db.profile.textLootColor = self:RGBToHex(r, g,
-                                                                          b)
+                        set = function(_, r, g, b, a)
+                            self.db.profile.textLootColor = self:RGBToString(r,
+                                                                             g,
+                                                                             b,
+                                                                             a)
                         end
                     },
                     textWarnColor = {
@@ -1884,11 +1894,14 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 2.4,
                         get = function()
+                            -- print("textWarnColor", self.db.profile.textWarnColor)
                             return self:HexToRGB(self.db.profile.textWarnColor)
                         end,
-                        set = function(_, r, g, b)
-                            self.db.profile.textWarnColor = self:RGBToHex(r, g,
-                                                                          b)
+                        set = function(_, r, g, b, a)
+                            self.db.profile.textWarnColor = self:RGBToString(r,
+                                                                             g,
+                                                                             b,
+                                                                             a)
                         end
                     },
                     textPickColor = {
@@ -1898,25 +1911,30 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 2.5,
                         get = function()
+                            -- print("textPickColor", self.db.profile.textPickColor)
                             return self:HexToRGB(self.db.profile.textPickColor)
                         end,
-                        set = function(_, r, g, b)
-                            self.db.profile.textPickColor = self:RGBToHex(r, g,
-                                                                          b)
+                        set = function(_, r, g, b, a)
+                            self.db.profile.textPickColor = self:RGBToString(r,
+                                                                             g,
+                                                                             b,
+                                                                             a)
                         end
                     },
                     textBuyColor = {
-                        name = _G.AUCTION_HOUSE_BUY_BUTTON,
+                        name = L("Buy"),
                         desc = L("Requires Reload to take effect"),
                         type = "color",
                         width = optionsWidth,
                         order = 2.6,
                         get = function()
+                            -- print("textBuyColor", self.db.profile.textBuyColor)
                             return self:HexToRGB(self.db.profile.textBuyColor)
                         end,
-                        set = function(_, r, g, b)
-                            self.db.profile.textBuyColor =
-                                self:RGBToHex(r, g, b)
+                        set = function(_, r, g, b, a)
+                            self.db.profile.textBuyColor = self:RGBToString(r,
+                                                                            g,
+                                                                            b, a)
                         end
                     },
                     customTextColorApply = {
@@ -1926,6 +1944,15 @@ function addon.settings:CreateAceOptionsPanel()
                         order = 2.9,
                         confirm = requiresReload,
                         func = function() _G.ReloadUI() end -- TODO easier redraw?
+                    },
+                    customTextColorReset = {
+                        name = _G.RESET,
+                        type = 'execute',
+                        width = optionsWidth,
+                        order = 2.91,
+                        func = function()
+                            self:ResetTextColors()
+                        end
                     },
                     guideWindowHeader = {
                         name = L("Guide Window"),
@@ -2447,51 +2474,78 @@ function addon.settings:CheckAddonCompatibility()
 end
 
 -- https://wowwiki-archive.fandom.com/wiki/USERAPI_RGBToHex
-function addon.settings:RGBToHex(r, g, b)
-    r = r <= 255 and r >= 0 and r or 0
-    g = g <= 255 and g >= 0 and g or 0
-    b = b <= 255 and b >= 0 and b or 0
+function addon.settings:RGBToString(r, g, b, a)
+    if type(r) == "table" then
+        a = r.a
+        g = r.g
+        b = r.b
+        r = r.r
+    end
+    print("r", r, "g", g, "b", b, "a", a)
 
-    return fmt("FF%02x%02x%02x", r, g, b)
+    print("RGBToString",
+          string.format("%02x%02x%02x%02x", a * 255, r * 255, g * 255, b * 255))
+    return string.format("%02x%02x%02x%02x", a * 255, r * 255, g * 255, b * 255)
 end
 
 -- https://wowwiki-archive.fandom.com/wiki/USERAPI_HexToRGB
 function addon.settings:HexToRGB(hexString)
-    if not hexString then return unpack(addon.activeTheme.textColor), 1 end
+    print("HexToRGB", hexString)
+    if not hexString then
+        print("Invalid hexString")
+        return unpack(addon.activeTheme.textColor) -- , 1
+    end
 
-    -- Ignore default 'FF' prefix
-    local rhex, ghex, bhex = hexString:sub(3, 4), hexString:sub(5, 6),
-                             hexString:sub(7, 8)
+    local ahex, rhex, ghex, bhex = hexString:sub(1, 2), hexString:sub(3, 4),
+                                   hexString:sub(5, 6), hexString:sub(7, 8)
 
-    if rhex and ghex and bhex then
-        return tonumber(rhex, 16), tonumber(ghex, 16), tonumber(bhex, 16), 1
+    print("rhex", rhex, "tonumber(rhex, 16)", tonumber(rhex, 16),
+          "tonumber(rhex, 16) * 255", tonumber(rhex, 16) / 255)
+    if ahex and rhex and ghex and bhex then
+        return tonumber(rhex, 16) / 255, tonumber(ghex, 16) / 255,
+               tonumber(bhex, 16) / 255 -- , tonumber(ahex or 1, 16) / 255
     else
-        return unpack(addon.activeTheme.textColor), 1
+        print("Using default")
+        return unpack(addon.activeTheme.textColor) -- , 1
     end
 end
 
+function addon.settings:LoadTextColors()
+    print("Loaded text colors")
+    _G.RXPD = addon.guideTextColors
+    addon.guideTextColors["RXP_FRIENDLY"] = self.db.profile.textFriendlyColor
+    addon.guideTextColors["RXP_ENEMY"] = self.db.profile.textEnemyColor
+    addon.guideTextColors["RXP_LOOT"] = self.db.profile.textLootColor
+    addon.guideTextColors["RXP_WARN"] = self.db.profile.textWarnColor
+    addon.guideTextColors["RXP_PICK"] = self.db.profile.textPickColor
+    addon.guideTextColors["RXP_BUY"] = self.db.profile.textBuyColor
+end
+
+function addon.settings:ResetTextColors()
+    print("Resetting colors")
+    self.db.profile.textEnemyColor = addon.guideTextColors.default['RXP_ENEMY']
+    self.db.profile.textFriendlyColor =
+        addon.guideTextColors.default['RXP_FRIENDLY']
+    self.db.profile.textLootColor = addon.guideTextColors.default['RXP_LOOT']
+    self.db.profile.textWarnColor = addon.guideTextColors.default['RXP_WARN']
+    self.db.profile.textPickColor = addon.guideTextColors.default['RXP_PICK']
+    self.db.profile.textBuyColor = addon.guideTextColors.default['RXP_BUY']
+    self:LoadTextColors()
+end
+
 function addon.settings:ReplaceColors(textLine)
-    local guideTextColors = { -- TODO persist lookup from settings
-        ["RXP_FRIENDLY"] = addon.settings.db.profile.textFriendlyColor,
-        ["RXP_ENEMY"] = addon.settings.db.profile.textEnemyColor,
-        ["RXP_LOOT"] = addon.settings.db.profile.textLootColor,
-        ["RXP_WARN"] = addon.settings.db.profile.textWarnColor,
-        ["RXP_PICK"] = addon.settings.db.profile.textPickColor,
-        ["RXP_BUY"] = addon.settings.db.profile.textBuyColor
-    }
-
-    -- TODO reverse lookup for color overrides
-    if textLine:find('|cFF') and false then
-        -- TODO
-        for k, v in pairs(guideTextColors) do end
-    end
-
     -- Replace text placeholders
-    if textLine:find('RXP_') then
-        for placeholder, hex in pairs(guideTextColors) do
-            textLine = textLine:gsub(placeholder, hex)
-        end
+    for RXP_ in string.gmatch(textLine, "RXP_[A-Z]+") do
+        print("Replacing RXP_", RXP_)
+        textLine = textLine:gsub(RXP_, addon.guideTextColors[RXP_])
     end
+
+    -- TODO regex find all RXP_ matches then lookup color
+    -- TODO reverse lookup for color overrides
+    -- if textLine:find('|cFF') and false then
+    -- TODO
+    --    for k, v in pairs(guideTextColors) do end
+    -- end
 
     return textLine
 end

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -2490,29 +2490,22 @@ end
 
 -- https://wowwiki-archive.fandom.com/wiki/USERAPI_HexToRGB
 function addon.settings:HexToRGB(hexString)
-    print("HexToRGB", hexString)
     if not hexString then
-        print("Invalid hexString")
         return unpack(addon.activeTheme.textColor) -- , 1
     end
 
     local ahex, rhex, ghex, bhex = hexString:sub(1, 2), hexString:sub(3, 4),
                                    hexString:sub(5, 6), hexString:sub(7, 8)
 
-    print("rhex", rhex, "tonumber(rhex, 16)", tonumber(rhex, 16),
-          "tonumber(rhex, 16) * 255", tonumber(rhex, 16) / 255)
     if ahex and rhex and ghex and bhex then
         return tonumber(rhex, 16) / 255, tonumber(ghex, 16) / 255,
                tonumber(bhex, 16) / 255 -- , tonumber(ahex or 1, 16) / 255
     else
-        print("Using default")
         return unpack(addon.activeTheme.textColor) -- , 1
     end
 end
 
 function addon.settings:LoadTextColors()
-    print("Loaded text colors")
-    _G.RXPD = addon.guideTextColors
     addon.guideTextColors["RXP_FRIENDLY"] = self.db.profile.textFriendlyColor
     addon.guideTextColors["RXP_ENEMY"] = self.db.profile.textEnemyColor
     addon.guideTextColors["RXP_LOOT"] = self.db.profile.textLootColor
@@ -2522,7 +2515,6 @@ function addon.settings:LoadTextColors()
 end
 
 function addon.settings:ResetTextColors()
-    print("Resetting colors")
     self.db.profile.textEnemyColor = addon.guideTextColors.default['RXP_ENEMY']
     self.db.profile.textFriendlyColor =
         addon.guideTextColors.default['RXP_FRIENDLY']

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -1947,6 +1947,15 @@ function addon.settings:CreateAceOptionsPanel()
                             self:ResetTextColors()
                         end
                     },
+                    disableColorText = {
+                        name = L("Disable Colors"),
+                        type = 'execute',
+                        width = optionsWidth,
+                        order = 2.92,
+                        func = function()
+                            self:DisableTextColors()
+                        end
+                    },
                     guideWindowHeader = {
                         name = L("Guide Window"),
                         type = "header",
@@ -2468,12 +2477,7 @@ end
 
 -- https://wowwiki-archive.fandom.com/wiki/USERAPI_RGBToHex
 function addon.settings:RGBToString(r, g, b, a)
-    if type(r) == "table" then
-        a = r.a
-        g = r.g
-        b = r.b
-        r = r.r
-    end
+    a = a or 1
 
     return string.format("%02x%02x%02x%02x", a * 255, r * 255, g * 255, b * 255)
 end
@@ -2512,6 +2516,18 @@ function addon.settings:ResetTextColors()
     self.db.profile.textWarnColor = addon.guideTextColors.default['RXP_WARN']
     self.db.profile.textPickColor = addon.guideTextColors.default['RXP_PICK']
     self.db.profile.textBuyColor = addon.guideTextColors.default['RXP_BUY']
+    self:LoadTextColors()
+end
+
+function addon.settings:DisableTextColors()
+    local default = self:RGBToString(unpack(addon.activeTheme.textColor))
+
+    self.db.profile.textEnemyColor = default
+    self.db.profile.textFriendlyColor = default
+    self.db.profile.textLootColor = default
+    self.db.profile.textWarnColor = default
+    self.db.profile.textPickColor = default
+    self.db.profile.textBuyColor = default
     self:LoadTextColors()
 end
 

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -31,8 +31,6 @@ if not addon.settings.gui then
     addon.settings.gui = {selectedDeleteGuide = "", importStatusHistory = {}}
 end
 
-local settingsCache = {}
-
 function addon.settings.ChatCommand(input)
     if not input then
         _G.InterfaceOptionsFrame_OpenToCategory(addon.RXPOptions)

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -136,7 +136,12 @@ function addon.settings:InitializeSettings()
             enableThemeLiveReload = true,
 
             -- Text colors
-            textEnemyColor = addon.guideTextColors['RXP_ENEMY']
+            textEnemyColor = addon.guideTextColors['RXP_ENEMY'],
+            textFriendlyColor = addon.guideTextColors['RXP_FRIENDLY'],
+            textLootColor = addon.guideTextColors['RXP_LOOTY'],
+            textWarnColor = addon.guideTextColors['RXP_WARN'],
+            textPickColor = addon.guideTextColors['RXP_PICK'],
+            textBuyColor = addon.guideTextColors['RXP_BUY']
         }
     }
 
@@ -1842,6 +1847,86 @@ function addon.settings:CreateAceOptionsPanel()
                                                                            b)
                         end
                     },
+                    textFriendlyColor = {
+                        name = _G.FRIENDLY,
+                        desc = L("Requires Reload to take effect"),
+                        type = "color",
+                        width = optionsWidth,
+                        order = 2.2,
+                        get = function()
+                            return self:HexToRGB(self.db.profile
+                                                     .textFriendlyColor)
+                        end,
+                        set = function(_, r, g, b)
+                            self.db.profile.textFriendlyColor = self:RGBToHex(r,
+                                                                              g,
+                                                                              b)
+                        end
+                    },
+                    textLootColor = {
+                        name = _G.LOOT,
+                        desc = L("Requires Reload to take effect"),
+                        type = "color",
+                        width = optionsWidth,
+                        order = 2.3,
+                        get = function()
+                            return self:HexToRGB(self.db.profile.textLootColor)
+                        end,
+                        set = function(_, r, g, b)
+                            self.db.profile.textLootColor = self:RGBToHex(r, g,
+                                                                          b)
+                        end
+                    },
+                    textWarnColor = {
+                        name = L("Warning"),
+                        desc = L("Requires Reload to take effect"),
+                        type = "color",
+                        width = optionsWidth,
+                        order = 2.4,
+                        get = function()
+                            return self:HexToRGB(self.db.profile.textWarnColor)
+                        end,
+                        set = function(_, r, g, b)
+                            self.db.profile.textWarnColor = self:RGBToHex(r, g,
+                                                                          b)
+                        end
+                    },
+                    textPickColor = {
+                        name = L("Pick Up"),
+                        desc = L("Requires Reload to take effect"),
+                        type = "color",
+                        width = optionsWidth,
+                        order = 2.5,
+                        get = function()
+                            return self:HexToRGB(self.db.profile.textPickColor)
+                        end,
+                        set = function(_, r, g, b)
+                            self.db.profile.textPickColor = self:RGBToHex(r, g,
+                                                                          b)
+                        end
+                    },
+                    textBuyColor = {
+                        name = _G.AUCTION_HOUSE_BUY_BUTTON,
+                        desc = L("Requires Reload to take effect"),
+                        type = "color",
+                        width = optionsWidth,
+                        order = 2.6,
+                        get = function()
+                            return self:HexToRGB(self.db.profile.textBuyColor)
+                        end,
+                        set = function(_, r, g, b)
+                            self.db.profile.textBuyColor =
+                                self:RGBToHex(r, g, b)
+                        end
+                    },
+                    customTextColorApply = {
+                        name = _G.APPLY,
+                        type = 'execute',
+                        width = optionsWidth,
+                        order = 2.9,
+                        confirm = requiresReload,
+                        func = function() _G.ReloadUI() end -- TODO easier redraw?
+                    },
                     guideWindowHeader = {
                         name = L("Guide Window"),
                         type = "header",
@@ -2381,19 +2466,18 @@ function addon.settings:HexToRGB(hexString)
     if rhex and ghex and bhex then
         return tonumber(rhex, 16), tonumber(ghex, 16), tonumber(bhex, 16), 1
     else
-        print("HexToRGB:else activeTheme.textColor")
         return unpack(addon.activeTheme.textColor), 1
     end
 end
 
 function addon.settings:ReplaceColors(textLine)
     local guideTextColors = { -- TODO persist lookup from settings
-        ["RXP_FRIENDLY"] = "FF00FF25",
+        ["RXP_FRIENDLY"] = addon.settings.db.profile.textFriendlyColor,
         ["RXP_ENEMY"] = addon.settings.db.profile.textEnemyColor,
-        ["RXP_LOOT"] = "FF00BCD4",
-        ["RXP_WARN"] = "FFFCDC00",
-        ["RXP_PICK"] = "FFDB2EEF",
-        ["RXP_BUY"] = "FF0E8312"
+        ["RXP_LOOT"] = addon.settings.db.profile.textLootColor,
+        ["RXP_WARN"] = addon.settings.db.profile.textWarnColor,
+        ["RXP_PICK"] = addon.settings.db.profile.textPickColor,
+        ["RXP_BUY"] = addon.settings.db.profile.textBuyColor
     }
 
     -- TODO reverse lookup for color overrides

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -133,7 +133,10 @@ function addon.settings:InitializeSettings()
             -- Themes
             activeTheme = 'Default',
             customTheme = addon.customThemeBase,
-            enableThemeLiveReload = true
+            enableThemeLiveReload = true,
+
+            -- Text colors
+            textEnemyColor = addon.guideTextColors['RXP_ENEMYY']
         }
     }
 
@@ -1766,7 +1769,7 @@ function addon.settings:CreateAceOptionsPanel()
                             return self.db.profile.activeTheme ~= 'Custom'
                         end
                     },
-                    customThemeTextColor = { -- TODO
+                    customThemeTextColor = {
                         name = L("Text Color"), -- TODO locale
                         desc = L("Requires Reload to take effect"),
                         type = "color",
@@ -1819,11 +1822,32 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 1.92
                     },
+                    textColorsHeader = {
+                        name = _G.LOCALE_TEXT_LABEL,
+                        type = "header",
+                        width = "full",
+                        order = 2.0
+                    },
+                    textEnemyColor = {
+                        name = _G.COMBATLOG_HIGHLIGHT_KILL,
+                        desc = L("Requires Reload to take effect"),
+                        type = "color",
+                        width = optionsWidth,
+                        order = 2.1,
+                        get = function()
+                            return
+                                addon.HexToRGB(self.db.profile.textEnemyColor)
+                        end,
+                        set = function(_, r, g, b)
+                            self.db.profile.textEnemyColor = addon.HexToRGB(r,
+                                                                            g, b)
+                        end
+                    },
                     guideWindowHeader = {
                         name = L("Guide Window"),
                         type = "header",
                         width = "full",
-                        order = 2.0
+                        order = 3.0
                     },
                     windowScale = {
                         name = L("Window Scale"),
@@ -1831,7 +1855,7 @@ function addon.settings:CreateAceOptionsPanel()
                             "Scale of the Main Window, use alt+left click on the main window to resize it"),
                         type = "range",
                         width = optionsWidth,
-                        order = 2.1,
+                        order = 3.1,
                         min = 0.2,
                         max = 2,
                         step = 0.05,
@@ -1845,7 +1869,7 @@ function addon.settings:CreateAceOptionsPanel()
                         desc = L("Change font size of the Guide Window"),
                         type = "range",
                         width = optionsWidth,
-                        order = 2.2,
+                        order = 3.2,
                         min = 9,
                         max = 18,
                         step = 1,
@@ -1863,7 +1887,7 @@ function addon.settings:CreateAceOptionsPanel()
                         values = {top = "Top", bottom = "Bottom"},
                         sorting = {"top", "bottom"},
                         width = optionsWidth,
-                        order = 2.3,
+                        order = 3.3,
                         set = function(info, value)
                             SetProfileOption(info, value)
                             addon.RXPFrame.SetStepFrameAnchor()
@@ -1875,7 +1899,7 @@ function addon.settings:CreateAceOptionsPanel()
                             "Show/Hide the bottom frame listing all the steps of the current guide"),
                         type = "toggle",
                         width = optionsWidth,
-                        order = 2.4,
+                        order = 3.4,
                         get = function()
                             return addon.RXPFrame.BottomFrame:GetHeight() >= 35
                         end,
@@ -1902,7 +1926,7 @@ function addon.settings:CreateAceOptionsPanel()
                             "Only shows current and future steps on the step list window"),
                         type = "toggle",
                         width = optionsWidth,
-                        order = 2.5,
+                        order = 3.5,
                         set = function(info, value)
                             SetProfileOption(info, value)
                             addon.RXPFrame.ScrollFrame.ScrollBar:SetValue(0)
@@ -1914,7 +1938,7 @@ function addon.settings:CreateAceOptionsPanel()
                             "Displays guides that are not applicable for your class/race such as starting zones for other races"),
                         type = "toggle",
                         width = optionsWidth,
-                        order = 2.6,
+                        order = 3.6,
                         set = function(info, value)
                             SetProfileOption(info, value)
                             addon.RXPFrame.GenerateMenuTable()
@@ -1926,7 +1950,7 @@ function addon.settings:CreateAceOptionsPanel()
                             "Automatically picks a suitable guide whenever you log in for the first time on a character"),
                         type = "toggle",
                         width = optionsWidth,
-                        order = 2.7,
+                        order = 3.7,
                         hidden = not addon.defaultGuideList,
                         set = function(info, value)
                             SetProfileOption(info, value)
@@ -1938,14 +1962,14 @@ function addon.settings:CreateAceOptionsPanel()
                         name = L("Active Items"),
                         type = "header",
                         width = "full",
-                        order = 3.0
+                        order = 4.0
                     },
                     activeItemsScale = {
                         name = L("Active Item Scale"), -- TODO locale
                         desc = L("Scale of the Active Item frame"),
                         type = "range",
                         width = optionsWidth,
-                        order = 3.1,
+                        order = 4.1,
                         min = 0.8,
                         max = 3,
                         step = 0.05,
@@ -1958,13 +1982,13 @@ function addon.settings:CreateAceOptionsPanel()
                         name = _G.MAP_OPTIONS_TEXT,
                         type = "header",
                         width = "full",
-                        order = 4.1
+                        order = 5.1
                     },
                     hideMiniMapPins = {
                         name = L("Hide Mini Map Pins"),
                         type = "toggle",
                         width = optionsWidth,
-                        order = 4.2,
+                        order = 5.2,
                         set = function(info, value)
                             SetProfileOption(info, value)
                             addon.updateMap = true
@@ -1976,7 +2000,7 @@ function addon.settings:CreateAceOptionsPanel()
                             "Show a targeting circle around active map pins"),
                         type = "toggle",
                         width = optionsWidth,
-                        order = 4.3,
+                        order = 5.3,
                         set = function(info, value)
                             SetProfileOption(info, value)
                             addon.updateMap = true
@@ -1987,7 +2011,7 @@ function addon.settings:CreateAceOptionsPanel()
                         desc = L("Number of map pins shown on the world map"),
                         type = "range",
                         width = optionsWidth,
-                        order = 4.4,
+                        order = 5.4,
                         min = 1,
                         max = 20,
                         step = 1,
@@ -2001,7 +2025,7 @@ function addon.settings:CreateAceOptionsPanel()
                         desc = L("Adjusts the size of the world map pins"),
                         type = "range",
                         width = optionsWidth,
-                        order = 4.5,
+                        order = 5.5,
                         min = 0.05,
                         max = 1,
                         step = 0.05,
@@ -2016,7 +2040,7 @@ function addon.settings:CreateAceOptionsPanel()
                             "If two or more steps are very close together, this addon will group them into a single pin on the map. Adjust this range to determine how close together two steps must be to form a group."),
                         type = "range",
                         width = optionsWidth,
-                        order = 4.6,
+                        order = 5.6,
                         min = 0.05,
                         max = 2,
                         step = 0.05,
@@ -2031,7 +2055,7 @@ function addon.settings:CreateAceOptionsPanel()
                             "The opacity of the black circles on the map and mini map"),
                         type = "range",
                         width = optionsWidth,
-                        order = 4.7,
+                        order = 5.7,
                         min = 0,
                         max = 1,
                         step = 0.05,
@@ -2336,4 +2360,34 @@ function addon.settings:CheckAddonCompatibility()
             end
         end
     end
+end
+
+function addon.settings:RGBToHex(r, g, b) end
+
+function addon.settings:HexToRGB(hexString) end
+
+function addon.settings:ReplaceColors(textLine)
+    local guideTextColors = { -- TODO persist lookup from settings
+        ["RXP_FRIENDLY"] = "FF00FF25",
+        ["RXP_ENEMY"] = addon.settings.db.profile.textEnemyColor,
+        ["RXP_LOOT"] = "FF00BCD4",
+        ["RXP_WARN"] = "FFFCDC00",
+        ["RXP_PICK"] = "FFDB2EEF",
+        ["RXP_BUY"] = "FF0E8312"
+    }
+
+    -- TODO reverse lookup for color overrides
+    if textLine:find('|cFF') and false then
+        -- TODO
+        for k, v in pairs(guideTextColors) do end
+    end
+
+    -- Replace text placeholders
+    if textLine:find('RXP_') then
+        for placeholder, hex in pairs(guideTextColors) do
+            textLine = textLine:gsub(placeholder, hex)
+        end
+    end
+
+    return textLine
 end

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -136,7 +136,7 @@ function addon.settings:InitializeSettings()
             enableThemeLiveReload = true,
 
             -- Text colors
-            textEnemyColor = addon.guideTextColors['RXP_ENEMYY']
+            textEnemyColor = addon.guideTextColors['RXP_ENEMY']
         }
     }
 
@@ -1835,12 +1835,11 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 2.1,
                         get = function()
-                            return
-                                addon.HexToRGB(self.db.profile.textEnemyColor)
+                            return self:HexToRGB(self.db.profile.textEnemyColor)
                         end,
                         set = function(_, r, g, b)
-                            self.db.profile.textEnemyColor = addon.HexToRGB(r,
-                                                                            g, b)
+                            self.db.profile.textEnemyColor = self:RGBToHex(r, g,
+                                                                           b)
                         end
                     },
                     guideWindowHeader = {
@@ -2362,9 +2361,30 @@ function addon.settings:CheckAddonCompatibility()
     end
 end
 
-function addon.settings:RGBToHex(r, g, b) end
+-- https://wowwiki-archive.fandom.com/wiki/USERAPI_RGBToHex
+function addon.settings:RGBToHex(r, g, b)
+    r = r <= 255 and r >= 0 and r or 0
+    g = g <= 255 and g >= 0 and g or 0
+    b = b <= 255 and b >= 0 and b or 0
 
-function addon.settings:HexToRGB(hexString) end
+    return fmt("FF%02x%02x%02x", r, g, b)
+end
+
+-- https://wowwiki-archive.fandom.com/wiki/USERAPI_HexToRGB
+function addon.settings:HexToRGB(hexString)
+    if not hexString then return unpack(addon.activeTheme.textColor), 1 end
+
+    -- Ignore default 'FF' prefix
+    local rhex, ghex, bhex = hexString:sub(3, 4), hexString:sub(5, 6),
+                             hexString:sub(7, 8)
+
+    if rhex and ghex and bhex then
+        return tonumber(rhex, 16), tonumber(ghex, 16), tonumber(bhex, 16), 1
+    else
+        print("HexToRGB:else activeTheme.textColor")
+        return unpack(addon.activeTheme.textColor), 1
+    end
+end
 
 function addon.settings:ReplaceColors(textLine)
     local guideTextColors = { -- TODO persist lookup from settings

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -138,12 +138,12 @@ function addon.settings:InitializeSettings()
             enableThemeLiveReload = true,
 
             -- Text colors
-            textEnemyColor = addon.guideTextColors.default['RXP_ENEMY'],
-            textFriendlyColor = addon.guideTextColors.default['RXP_FRIENDLY'],
-            textLootColor = addon.guideTextColors.default['RXP_LOOT'],
-            textWarnColor = addon.guideTextColors.default['RXP_WARN'],
-            textPickColor = addon.guideTextColors.default['RXP_PICK'],
-            textBuyColor = addon.guideTextColors.default['RXP_BUY']
+            textEnemyColor = addon.guideTextColors.default['RXP_ENEMY_'],
+            textFriendlyColor = addon.guideTextColors.default['RXP_FRIENDLY_'],
+            textLootColor = addon.guideTextColors.default['RXP_LOOT_'],
+            textWarnColor = addon.guideTextColors.default['RXP_WARN_'],
+            textPickColor = addon.guideTextColors.default['RXP_PICK_'],
+            textBuyColor = addon.guideTextColors.default['RXP_BUY_']
         }
     }
 
@@ -2500,22 +2500,36 @@ function addon.settings:HexToRGB(hexString)
 end
 
 function addon.settings:LoadTextColors()
-    addon.guideTextColors["RXP_FRIENDLY"] = self.db.profile.textFriendlyColor
-    addon.guideTextColors["RXP_ENEMY"] = self.db.profile.textEnemyColor
-    addon.guideTextColors["RXP_LOOT"] = self.db.profile.textLootColor
-    addon.guideTextColors["RXP_WARN"] = self.db.profile.textWarnColor
-    addon.guideTextColors["RXP_PICK"] = self.db.profile.textPickColor
-    addon.guideTextColors["RXP_BUY"] = self.db.profile.textBuyColor
+    local gtc = addon.guideTextColors
+    local p = self.db.profile
+    gtc["RXP_FRIENDLY_"] = p.textFriendlyColor
+    gtc["RXP_ENEMY_"] = p.textEnemyColor
+    gtc["RXP_LOOT_"] = p.textLootColor
+    gtc["RXP_WARN_"] = p.textWarnColor
+    gtc["RXP_PICK_"] = p.textPickColor
+    gtc["RXP_BUY_"] = p.textBuyColor
+
+    -- Setup reverse lookup
+    gtc[gtc.default["RXP_FRIENDLY_"]] = p.textFriendlyColor
+    gtc[gtc.default['RXP_ENEMY_']] = p.textEnemyColor
+    gtc[gtc.default["RXP_LOOT_"]] = p.textLootColor
+    gtc[gtc.default["RXP_WARN_"]] = p.textWarnColor
+    gtc[gtc.default["RXP_PICK_"]] = p.textPickColor
+    gtc[gtc.default["RXP_BUY_"]] = p.textBuyColor
+
+    -- TODO default to theme, but load order
+    -- self:RGBToString(unpack(addon.activeTheme.textColor))
+    gtc.default["error"] = {1, 1, 1}
 end
 
 function addon.settings:ResetTextColors()
-    self.db.profile.textEnemyColor = addon.guideTextColors.default['RXP_ENEMY']
+    self.db.profile.textEnemyColor = addon.guideTextColors.default['RXP_ENEMY_']
     self.db.profile.textFriendlyColor =
-        addon.guideTextColors.default['RXP_FRIENDLY']
-    self.db.profile.textLootColor = addon.guideTextColors.default['RXP_LOOT']
-    self.db.profile.textWarnColor = addon.guideTextColors.default['RXP_WARN']
-    self.db.profile.textPickColor = addon.guideTextColors.default['RXP_PICK']
-    self.db.profile.textBuyColor = addon.guideTextColors.default['RXP_BUY']
+        addon.guideTextColors.default['RXP_FRIENDLY_']
+    self.db.profile.textLootColor = addon.guideTextColors.default['RXP_LOOT_']
+    self.db.profile.textWarnColor = addon.guideTextColors.default['RXP_WARN_']
+    self.db.profile.textPickColor = addon.guideTextColors.default['RXP_PICK_']
+    self.db.profile.textBuyColor = addon.guideTextColors.default['RXP_BUY_']
     self:LoadTextColors()
 end
 
@@ -2532,18 +2546,20 @@ function addon.settings:DisableTextColors()
 end
 
 function addon.settings:ReplaceColors(textLine)
+    -- TODO handle nil lookups
+
     -- Replace text placeholders
-    for RXP_ in string.gmatch(textLine, "RXP_[A-Z]+") do
-        print("Replacing RXP_", RXP_)
-        textLine = textLine:gsub(RXP_, addon.guideTextColors[RXP_])
+    -- TODO handle RXP_FOO_ActualThing
+    for RXP_ in string.gmatch(textLine, "RXP_[A-Z]+_") do
+        textLine = textLine:gsub(RXP_, addon.guideTextColors[RXP_] or
+                                     addon.guideTextColors.default["error"])
     end
 
-    -- TODO regex find all RXP_ matches then lookup color
-    -- TODO reverse lookup for color overrides
-    -- if textLine:find('|cFF') and false then
-    -- TODO
-    --    for k, v in pairs(guideTextColors) do end
-    -- end
+    -- Replace raw hex values
+    for hex in string.gmatch(textLine, "|c(%x%x%x%x%x%x%x%x)") do
+        textLine = textLine:gsub(hex, addon.guideTextColors[hex] or
+                                     addon.guideTextColors.default["error"])
+    end
 
     return textLine
 end

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -1843,8 +1843,6 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 2.1,
                         get = function()
-                            print("textEnemyColor",
-                                  self.db.profile.textEnemyColor)
                             return self:HexToRGB(self.db.profile.textEnemyColor)
                         end,
                         set = function(_, r, g, b, a)
@@ -1861,7 +1859,6 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 2.2,
                         get = function()
-                            -- print("textFriendlyColor", self.db.profile.textFriendlyColor)
                             return self:HexToRGB(self.db.profile
                                                      .textFriendlyColor)
                         end,
@@ -1877,7 +1874,6 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 2.3,
                         get = function()
-                            -- print("textLootColor", self.db.profile.textLootColor)
                             return self:HexToRGB(self.db.profile.textLootColor)
                         end,
                         set = function(_, r, g, b, a)
@@ -1894,7 +1890,6 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 2.4,
                         get = function()
-                            -- print("textWarnColor", self.db.profile.textWarnColor)
                             return self:HexToRGB(self.db.profile.textWarnColor)
                         end,
                         set = function(_, r, g, b, a)
@@ -1911,7 +1906,6 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 2.5,
                         get = function()
-                            -- print("textPickColor", self.db.profile.textPickColor)
                             return self:HexToRGB(self.db.profile.textPickColor)
                         end,
                         set = function(_, r, g, b, a)
@@ -1928,7 +1922,6 @@ function addon.settings:CreateAceOptionsPanel()
                         width = optionsWidth,
                         order = 2.6,
                         get = function()
-                            -- print("textBuyColor", self.db.profile.textBuyColor)
                             return self:HexToRGB(self.db.profile.textBuyColor)
                         end,
                         set = function(_, r, g, b, a)
@@ -2481,10 +2474,7 @@ function addon.settings:RGBToString(r, g, b, a)
         b = r.b
         r = r.r
     end
-    print("r", r, "g", g, "b", b, "a", a)
 
-    print("RGBToString",
-          string.format("%02x%02x%02x%02x", a * 255, r * 255, g * 255, b * 255))
     return string.format("%02x%02x%02x%02x", a * 255, r * 255, g * 255, b * 255)
 end
 

--- a/Themes.lua
+++ b/Themes.lua
@@ -73,7 +73,9 @@ addon.customThemeBase = {
     author = _G.UnitName("player")
 }
 
-addon.guideTextColors = { -- TODO reverse lookup
+addon.guideTextColors = {}
+
+addon.guideTextColors.default = { -- TODO reverse lookup
     ["RXP_FRIENDLY"] = "FF00FF25",
     ["RXP_ENEMY"] = "FFFF5722",
     ["RXP_LOOT"] = "FF00BCD4",

--- a/Themes.lua
+++ b/Themes.lua
@@ -75,13 +75,14 @@ addon.customThemeBase = {
 
 addon.guideTextColors = {}
 
-addon.guideTextColors.default = { -- TODO reverse lookup
-    ["RXP_FRIENDLY"] = "FF00FF25",
-    ["RXP_ENEMY"] = "FFFF5722",
-    ["RXP_LOOT"] = "FF00BCD4",
-    ["RXP_WARN"] = "FFFCDC00",
-    ["RXP_PICK"] = "FFDB2EEF",
-    ["RXP_BUY"] = "FF0E8312"
+-- TODO move into themes
+addon.guideTextColors.default = {
+    ["RXP_FRIENDLY_"] = "FF00FF25",
+    ["RXP_ENEMY_"] = "FFFF5722",
+    ["RXP_LOOT_"] = "FF00BCD4",
+    ["RXP_WARN_"] = "FFFCDC00",
+    ["RXP_PICK_"] = "FFDB2EEF",
+    ["RXP_BUY_"] = "FF0E8312"
 }
 
 local function themeApplies(applicable)

--- a/Themes.lua
+++ b/Themes.lua
@@ -73,6 +73,15 @@ addon.customThemeBase = {
     author = _G.UnitName("player")
 }
 
+addon.guideTextColors = { -- TODO reverse lookup
+    ["RXP_FRIENDLY"] = "FF00FF25",
+    ["RXP_ENEMY"] = "FFFF5722",
+    ["RXP_LOOT"] = "FF00BCD4",
+    ["RXP_WARN"] = "FFFCDC00",
+    ["RXP_PICK"] = "FFDB2EEF",
+    ["RXP_BUY"] = "FF0E8312"
+}
+
 local function themeApplies(applicable)
     if applicable == nil then
         return true


### PR DESCRIPTION
More to tinker with, but just want to get this functionality in rather than continue delaying it.

Supports

* Replacing `RXP_FOO_` with built-in hex values, rather than guide devs copy/pasting a hex value all over the place
* Replacing default hex values with settings
* Disabling colors, e.g. white on everything