### PR TITLE
Fix error when GetInventoryItemID returns nil

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -4570,7 +4570,10 @@ function addon.functions.itemStat(self, ...)
             if element.stat == "QUALITY" then
                 stat = GetInventoryItemQuality("player", element.slot)
             elseif element.stat == "LEVEL" then
-                _, _, _, stat = GetItemInfo(GetInventoryItemID("player", element.slot))
+                local itemID = GetInventoryItemID("player", element.slot)
+                if itemID then
+                    _, _, _, stat = GetItemInfo(itemID)
+                end
             else
                 stat = stats[element.stat]
             end


### PR DESCRIPTION
A user reported to me via discord dm that he was no longer able to use the guide. He sent me this lua error: 

> Interface/AddOns/RXPGuides/functions.lua:4571: Usage: GetItemInfo(itemID|"name"|"itemlink")
> Time: Fri Mar 31 07:13:16 2023
> Count: 1
> Stack: Interface/AddOns/RXPGuides/functions.lua:4571: Usage: GetItemInfo(itemID|"name"|"itemlink")
> [string "=(tail call)"]: ?
> [string "=[C]"]: in function GetItemInfo'
> [string "@Interface/AddOns/RXPGuides/functions.lua"]:4571: in function callback'
> [string "@Interface/AddOns/RXPGuides/GuideWindow.lua"]:693: in function <Interface/AddOns/RXPGuides/GuideWindow.lua:392>
> [string "=[C]"]: in function SetStep'
> [string "@Interface/AddOns/RXPGuides/GuideWindow.lua"]:1303: in function LoadGuide'
> [string "@Interface/AddOns/RXPGuides/RXPGuides.lua"]:462: in function <Interface/AddOns/RXPGuides/RXPGuides.lua:441>
> [string "=[C]"]: ?
> [string "@Interface/AddOns/Atlas/Libs/AceAddon-3.0/AceAddon-3.0.lua"]:66: in function <...face/AddOns/Atlas/Libs/AceAddon-3.0/AceAddon-3.0.lua:61>
> [string "@Interface/AddOns/Atlas/Libs/AceAddon-3.0/AceAddon-3.0.lua"]:523: in function `EnableAddon'
> [string "@Interface/AddOns/Atlas/Libs/AceAddon-3.0/AceAddon-3.0.lua"]:626: in function <...face/AddOns/Atlas/Libs/AceAddon-3.0/AceAddon-3.0.lua:611>
> 
> Locals: \<none\>

If you think there is a better solution then just fix it your way.