### PR TITLE
Fix retail gossip option automation

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -3540,9 +3540,7 @@ function addon.functions.skipgossip(self, text, ...)
     if event == "GOSSIP_SHOW" then
         -- print(id,'GS',nArgs)
         local trainerId,name = addon.SelectGossipType("trainer",true)
-        if not name then return end
-
-        if trainerId and GossipGetNumOptions() >= 3 or strupper(name):find(strupper(localizedClass)) then
+        if (trainerId and GossipGetNumOptions() >= 3) or (name and strupper(name):find(strupper(localizedClass))) then
             --Ignore dualspec prompt
             return
         elseif nArgs == 0 or not id then


### PR DESCRIPTION
Fixes
```
Message: Interface/AddOns/RXPGuides/functions.lua:3542: bad argument #1 to 'strupper' (string expected, got nil)
Time: Sat Apr 29 22:03:07 2023
Count: 1
Stack: Interface/AddOns/RXPGuides/functions.lua:3542: bad argument #1 to 'strupper' (string expected, got nil)
[string "=[C]"]: ?
[string "=[C]"]: in function strupper'
[string "@Interface/AddOns/RXPGuides/functions.lua"]:3542: in function callback'
[string "@Interface/AddOns/RXPGuides/GuideWindow.lua"]:793: in function <Interface/AddOns/RXPGuides/GuideWindow.lua:788>

Locals:
```