### PR TITLE
Add step index in quest log tooltip.

### DIFF
--- a/QuestLog.lua
+++ b/QuestLog.lua
@@ -73,7 +73,11 @@ function addon.UpdateQuestButton(index)
                 end
                 local solo = step.solo or not step.group
                 local grpTbl = guides[entry.group]
-                grpTbl[entry.name] = grpTbl[entry.name] or solo
+                local entryDisplayName = entry.name
+                if step.index then
+                    entryDisplayName = entryDisplayName .. L(" at step ") .. step.index
+                end
+                grpTbl[entryDisplayName] = grpTbl[entryDisplayName] or solo
                 --print(entry.name,entry.group,solo,qid)
             end
         end


### PR DESCRIPTION
Sometimes I pick quests earlier (or later) than intended and is helpful to see at what step pick up/turn in would happen.

<img width="468" alt="Screenshot 2023-07-27 at 20 35 58" src="https://github.com/RestedXP/RXPGuides/assets/477645/07eaab39-08d1-45a9-a5ae-4ab7c2150c55">
