### PR TITLE
Persist frame positions in profile

### DIFF
--- a/RXPGuides.lua
+++ b/RXPGuides.lua
@@ -773,11 +773,10 @@ function addon:OnEnable()
     for frameName, frame in pairs(addon.enabledFrames) do
         if frame.IsFeatureEnabled() then
             -- Restore saved positions if applicable
-            -- TODO optimize for only profile changes?
             if addon.settings.profile.framePositions[frameName] then
                 point, relativeTo, relativePoint, offsetX, offsetY = unpack(addon.settings.profile.framePositions[frameName])
 
-                frame:SetPoint(point, relativeTo, relativePoint ,offsetX, offsetY)
+                frame:SetPoint(point, relativeTo, relativePoint, offsetX, offsetY)
             end
             frame:SetShown(addon.settings.profile.showEnabled)
         end

--- a/RXPGuides.lua
+++ b/RXPGuides.lua
@@ -742,6 +742,7 @@ function addon:OnEnable()
 
     self:RegisterEvent("PLAYER_ENTERING_WORLD")
     self:RegisterEvent("PLAYER_LEAVING_WORLD")
+    self:RegisterEvent("PLAYER_LOGOUT")
 
     self:RegisterEvent("CALENDAR_UPDATE_EVENT_LIST")
     self:RegisterEvent("ZONE_CHANGED")
@@ -831,6 +832,24 @@ function addon:PLAYER_ENTERING_WORLD(_, isInitialLogin)
 end
 --addon:LoadGuideTable(addon.defaultGroupHC, addon.defaultGuideHC)
 function addon:PLAYER_LEAVING_WORLD() addon.isHidden = true end
+
+-- Sent when the player logs out or the UI is reloaded, just before SavedVariables are saved
+-- Note, this is only for profile sharing, frames are preserved normally with layout.xml
+function addon:PLAYER_LOGOUT()
+    if not addon.settings.profile.framePositions then
+        addon.settings.profile.framePositions = {}
+    end
+
+    local point, relativePoint, offsetX, offsetY
+    -- Dump enabled frame locations
+    for frameName, frame in pairs(addon.enabledFrames) do
+        -- if frame.IsFeatureEnabled() then
+        point, _, relativePoint, offsetX, offsetY = frame:GetPoint()
+
+        addon.settings.profile.framePositions[frameName] = {point, relativePoint, offsetX, offsetY}
+    end
+
+end
 
 function addon:CALENDAR_UPDATE_EVENT_LIST()
     -- Required by .dmf

--- a/RXPGuides.lua
+++ b/RXPGuides.lua
@@ -769,8 +769,16 @@ function addon:OnEnable()
         self:RegisterEvent("QUEST_DATA_LOAD_RESULT")
     end
 
-    for _, frame in pairs(addon.enabledFrames) do
+    local point, relativeTo, relativePoint, offsetX, offsetY
+    for frameName, frame in pairs(addon.enabledFrames) do
         if frame.IsFeatureEnabled() then
+            -- Restore saved positions if applicable
+            -- TODO optimize for only profile changes?
+            if addon.settings.profile.framePositions[frameName] then
+                point, relativeTo, relativePoint, offsetX, offsetY = unpack(addon.settings.profile.framePositions[frameName])
+
+                frame:SetPoint(point, relativeTo, relativePoint ,offsetX, offsetY)
+            end
             frame:SetShown(addon.settings.profile.showEnabled)
         end
     end
@@ -840,13 +848,13 @@ function addon:PLAYER_LOGOUT()
         addon.settings.profile.framePositions = {}
     end
 
-    local point, relativePoint, offsetX, offsetY
+    local point, relativeTo, relativePoint, offsetX, offsetY
     -- Dump enabled frame locations
     for frameName, frame in pairs(addon.enabledFrames) do
         -- if frame.IsFeatureEnabled() then
-        point, _, relativePoint, offsetX, offsetY = frame:GetPoint()
+        point, relativeTo, relativePoint, offsetX, offsetY = frame:GetPoint()
 
-        addon.settings.profile.framePositions[frameName] = {point, relativePoint, offsetX, offsetY}
+        addon.settings.profile.framePositions[frameName] = {point, relativeTo, relativePoint, offsetX, offsetY}
     end
 
 end

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -2946,6 +2946,20 @@ function addon.settings:RefreshProfile()
     addon.UpdateMap()
     addon.RXPFrame.GenerateMenuTable()
     addon.RXPFrame.SetStepFrameAnchor()
+
+    -- Restore frame positions on profile change
+    local point, relativeTo, relativePoint, offsetX, offsetY
+    for frameName, frame in pairs(addon.enabledFrames) do
+        if frame.IsFeatureEnabled() then
+            -- Restore saved positions if applicable
+            if addon.settings.profile.framePositions[frameName] then
+                point, relativeTo, relativePoint, offsetX, offsetY = unpack(addon.settings.profile.framePositions[frameName])
+
+                frame:SetPoint(point, relativeTo, relativePoint, offsetX, offsetY)
+            end
+            frame:SetShown(addon.settings.profile.showEnabled)
+        end
+    end
 end
 
 function addon.settings:CheckAddonCompatibility()

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -166,7 +166,9 @@ function addon.settings:InitializeSettings()
             emergencyThreshold = 0.2,
             enableEmergencyIconAnimations = true,
 
-            dungeons = {}
+            dungeons = {},
+
+            framePositions = {},
         }
     }
 


### PR DESCRIPTION
Partially handles #109 

> Update existing profiles to include all aspects of frame data
>> Currently Profiles do not restore frame position data. Always places it on the left middle of the screen

Saves and restores frame positions for all primary frames, using the same table as hide/show does.