### PR TITLE
Fix Maelstrom Weapon Steps

### DIFF
--- a/Guides/SoD/Shaman.lua
+++ b/Guides/SoD/Shaman.lua
@@ -2365,10 +2365,10 @@ step
 step
     .train 410100,1
     #loop
-    .goto Dustwallow Marsch,42.6,30.0,25,0
-    .goto Dustwallow Marsch,35.2,44.6,25,0
-    .goto Dustwallow Marsch,42.6,62.0,25,0
-    .goto Dustwallow Marsch,50.0,54.0,25,0
+    .goto Dustwallow Marsh,42.6,30.0,25,0
+    .goto Dustwallow Marsh,35.2,44.6,25,0
+    .goto Dustwallow Marsh,42.6,62.0,25,0
+    .goto Dustwallow Marsh,50.0,54.0,25,0
     >>Kill |cRXP_ENEMY_Withervine Mire Beast|r. Loot them for |T132846:0|t|cRXP_LOOT_Rumbling Essences|r
     .complete 79363,1 -- Power of da Water
     .mob Withervine Mire Beast

--- a/Guides/SoD/Shaman.lua
+++ b/Guides/SoD/Shaman.lua
@@ -2356,7 +2356,7 @@ step
     .goto Desolace,69.4,64.6,25,0
     .goto Desolace,58.8,65.6,25,0
     >>Kill |cRXP_ENEMY_Whirlwind Ripper|r. Loot them for |T132845:0|t|cRXP_LOOT_Whirling Essence|r
-    .complete  79361 -- Power of da Wind
+    .complete 79361,1 -- Power of da Wind
     .mob Whirlwind Ripper
 step
     .train 410100,1


### PR DESCRIPTION
This PR fixes the guide for the Shaman Maelstrom Weapon rune.