### PR TITLE
Add Shadow Wardens quests to Molten Front

### DIFF
--- a/Guides/Dailies/Cataclysm/Molten Front.lua
+++ b/Guides/Dailies/Cataclysm/Molten Front.lua
@@ -1265,7 +1265,7 @@ step
     .zone 198 >> Take the Portal to Mount Hyjal
 step
     .isQuestComplete 29181
-    .goto 198,47.017,91.361
+    .goto 198,43.5,45.9
     >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Skylord Omnuron|r 
     .turnin 29181 >>Turn in Druids of the Talon
     .target Skylord Omnuron
@@ -2115,6 +2115,12 @@ step
     .goto 198,27.484,56.394
     .zone 338 >> Go through the Portal to the Firelands
 step
+    .isQuestComplete 29294
+    .goto 338,50.7,87.3
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Avrilla|r
+    .daily 29255,29299,29257 >> Accept whichever random daily quest is offered
+    .target Avrilla
+step
     .goto 338,48.513,86.257
     >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Rayne Feathersong|r 
     .daily 29139,29143 >>Accept whichever random daily quest is offered
@@ -2136,6 +2142,45 @@ step
     >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_General Taldris Moonfall|r 
     .dailyturnin 29128 >>Turn in The Protectors of Hyjal
     .target General Taldris Moonfall
+step -- 29255 Embergris
+    .isOnQuest 29255
+    #sticky
+    #label Embergris
+    #loop
+    .goto 338,47.6,79.6,45,0
+    .goto 338,43.8,74.0,45,0
+    .goto 338,45.8,64.2,45,0
+    .goto 338,52.8,64.4,45,0
+    .goto 338,53.6,79.6,45,0
+    >>Kill |cRXP_ENEMY_Charred Vanquishers|r and |cRXP_ENEMY_Charred Soldiers|r. Loot them for their |cRXP_LOOT_Embergris|r
+    .complete 29255,1 -- Embergris (5)
+    .mob Charred Vanquisher
+    .mob Charred Soldier
+step -- 29299 Some Like it Hot
+    .isOnQuest 29299
+    #sticky
+    #label SomeLikeItHot
+    #loop
+    .goto 338,43.7,64.1,45,0
+    .goto 338,46.7,62.5,45,0
+    .goto 338,53.6,65.4,45,0
+    .goto 338,54.6,59.9,45,0
+    .goto 338,43.5,50.0,45,0
+    >>Kill |cRXP_ENEMY_Emberspit Scorpions|r and let the Crimson Lasher following you stand in the fire it drops when it dies.
+    .complete 29299,6 -- Help the Crimson Lasher Drink from Ember Pools (6)
+    .mob Emberspit Scorpion
+step -- 29257 Steal Magmolia
+    .isOnQuest 29257
+    #sticky
+    #label StealMagmolia
+    #loop
+    .goto 338,47.6,79.6,45,0
+    .goto 338,43.8,74.0,45,0
+    .goto 338,45.8,64.2,45,0
+    .goto 338,52.8,64.4,45,0
+    .goto 338,53.6,79.6,45,0
+    >>Loot |cRXP_LOOT_Magmolia|r on the ground.
+    .complete 29255,1 -- Magmolia (8)
 step -- 29138 Burn Victims
     .isOnQuest 29138
     #sticky
@@ -2272,6 +2317,15 @@ step
     #optional
     #requires WispAway
 step
+    #optional
+    #requires Embergris
+step
+    #optional
+    #requires SomeLikeItHot
+step
+    #optional
+    #requires StealMagmolia
+step
     .isQuestComplete 29139
     .goto 338,48.513,86.257
     >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Rayne Feathersong|r 
@@ -2283,6 +2337,24 @@ step
     >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Rayne Feathersong|r 
     .dailyturnin 29143 >>Turn in Wisp Away
     .target Rayne Feathersong
+step
+    .isQuestComplete 29255
+    .goto 338,50.7,87.3
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Avrilla|r
+    .dailyturnin 29255 >>Turn in Embergris
+    .target Avrilla
+step
+    .isQuestComplete 29299
+    .goto 338,50.7,87.3
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Avrilla|r
+    .dailyturnin 29299 >>Turn in Some Like It Hot
+    .target Avrilla
+step
+    .isQuestComplete 29257
+    .goto 338,50.7,87.3
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Avrilla|r
+    .dailyturnin 29257 >>Turn in Steal Magmolia
+    .target Avrilla
 step
     .isQuestComplete 29179
     .goto 338,45.589,85.822
@@ -2596,4 +2668,974 @@ step
 step
     #label DruidEnd
     +|cRXP_WARN_You have completed all the available daily quests for today. Reload this same guide tomorrow (|r|cRXP_ENEMY_2.5|r - The Molten Front + Druids|cRXP_WARN_) to continue completing the daily quests until you have acquired enough|r |T513195:0|t[Marks of the World Tree]
+]])
+
+-- todo: this guide doesn't try to complete 29254 Little Lashers which
+-- activates the 3 quests at Avrilla and may require another lap at
+-- the entrance of the Molten Front to complete all the dailies
+RXPGuides.RegisterGuide([[
+#cata
+#version 1
+#group +The Molten Front
+#name C_2_TSOM_Wardens
+#displayname |cRXP_ENEMY_2.5|r - The Molten Front + Shadow Wardens
+
+step
+    #optional
+    .isQuestAvailable 29214
+    +|cRXP_WARN_You must first gather 150|r |T513195:0|t[Marks of the World Tree] |cRXP_WARN_and turn in the quest [The Shadow Wardens] in order to complete daily quests for them|r
+    >>|cRXP_WARN_Continue completing the (|r|cRXP_FRIENDLY_2.0|r - The Molten Front|cRXP_WARN_) guide until you have enough|r |T513195:0|t[Marks of the World Tree]
+    .goto 198,26.8,62.1
+    .turnin 29214 >>Turn in The Shadow Wardens
+    .target Captain Sayanna Stormrunner
+
+step
+    #optional
+    #completewith HyjalQuests
+	.zone 85 >> Travel to Orgrimmar << Horde
+	.zone 84 >> Travel to Stormwind << Alliance
+	.zoneskip 198
+    .zoneskip 338
+step
+    #optional
+    #completewith HyjalQuests
+    .goto 85,51.12,38.26 << Horde
+    .goto 84,76.199,18.690 << Alliance
+    .zone 198 >>Take the Portal to Hyjal
+    .zoneskip 338
+step
+    #optional
+    #completewith HyjalQuests
+    .goto 338,53.026,83.693
+    .zone 198 >> Take the Portal to Mount Hyjal
+    .zoneskip 338,1
+step --accepted back at sanctuary of malorne
+    .goto 198/1,-2088.800,4452.300
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Captain Soren Moonfall|r 
+    .target Captain Soren Moonfall
+    .daily 29128 >>Accept The Protectors of Hyjal
+step
+    #loop
+    .goto 198,27.108,62.009,5,0
+    .goto 198,27.170,62.563,5,0
+    +Talk to |cRXP_FRIENDLY_Matoclaw|r or |cRXP_FRIENDLY_Mylune|r and accept whichever daily quest is available
+    .questcount <1,29125,29147,29164,29101,29161
+    .target Matoclaw
+    .target Mylune
+step
+    #loop
+    #label HyjalQuests
+    .goto 198,27.527,62.510,5,0
+    .goto 198,27.172,62.565,5,0
+    +Talk to |cRXP_FRIENDLY_Matoclaw|r or |cRXP_FRIENDLY_Dorda'en Nightweaver|r and accept whichever daily quest is available
+    .questcount <1,29123,29149,29127,29163,29166,29247,29246,29248
+    .target Matoclaw
+    .target Dorda'en Nightweaver
+step
+    .isOnQuest 29166
+    #completewith KillNemesis
+    >>Loot the |cRXP_LOOT_Blueroot Vines|r on the ground
+    .complete 29166,1
+step
+    .isOnQuest 29123
+    #completewith KillNemesis
+    >>Kill the |cRXP_ENEMY_Invaders from the Firelands|r
+    .complete 29123,1
+    .mob Flame Terror
+    .mob Brimstone Hound
+    .mob Scarred Acolyte
+    .mob Charred Invader
+step
+    .isOnQuest 29149
+    #completewith KillNemesis
+    >>Kill the |cRXP_ENEMY_Invaders from the Firelands|r
+    .complete 29149,1
+    .mob Flame Terror
+    .mob Brimstone Hound
+    .mob Scarred Acolyte
+    .mob Charred Invader
+step
+    .isOnQuest 29127
+    #completewith KillNemesis
+    >>Kill the |cRXP_ENEMY_Invaders from the Firelands|r
+    .complete 29127,1
+    .mob Flame Terror
+    .mob Brimstone Hound
+    .mob Scarred Acolyte
+    .mob Charred Invader
+step
+    .isOnQuest 29163
+    #completewith KillNemesis
+    >>Kill the |cRXP_ENEMY_Invaders from the Firelands|r
+    .complete 29163,1
+    .mob Flame Terror
+    .mob Brimstone Hound
+    .mob Scarred Acolyte
+    .mob Charred Invader
+step
+    .isOnQuest 29101
+    #loop
+    .goto 198,22.89,59.91,70,0
+    .goto 198,18.58,56.71,70,0
+    .goto 198,15.11,48.85,70,0
+    .goto 198,19.97,46.22,70,0
+    >>Click on a |cRXP_FRIENDLY_Child of Tortolla|r
+    >>|cRXP_WARN_Aim towards the water and cast|r |T132219:0|t[Punt Turtle] |cRXP_WARN_(1)|r
+    .complete 29101,1 -- Child of Tortolla punted into water (5)
+    .target Child of Tortolla
+step
+    .isOnQuest 29164
+    #loop
+    .goto 198,23.06,59.99,0
+    .goto 198,16.01,50.51,0
+    .goto 198,10.29,36.11,0
+    .goto 198,23.06,59.99,70,0
+    .goto 198,19.29,58.54,70,0
+    .goto 198,16.01,50.51,70,0
+    .goto 198,14.98,43.10,70,0
+    .goto 198,10.29,36.11,70,0
+    >>Kill the |cRXP_ENEMY_Invaders from the Firelands|r
+    .use 69235 >> |cRXP_WARN_Use the|r |T134298:0|t[Fang of the Wolf] |cRXP_WARN_on their corpses|r
+    .complete 29164,1 -- Howl atop an invader's corpse (10)
+    .mob Flame Terror
+    .mob Brimstone Hound
+    .mob Scarred Acolyte
+    .mob Charred Invader
+step
+    .isOnQuest 29147
+    #completewith next
+    .cast 97241 >> |cRXP_WARN_Use the|r |T135992:0|t[Quill of the Bird-Queen] |cRXP_WARN_to transform into the|r |cRXP_FRIENDLY_Wings of Aviana|r
+    .use 69234
+step
+    .isOnQuest 29147
+    #loop
+    .goto 198,14.90,45.11,80,0
+    .goto 198,10.13,36.76,80,0
+    .goto 198,13.24,33.64,80,0
+    .goto 198,18.65,40.28,80,0
+    .use 69234 >> |cRXP_WARN_Use the|r |T132172:0|t[Call the Flock] (1) |cRXP_WARN_ability near |cRXP_ENEMY_Alpine Songbirds|r, |cRXP_ENEMY_Forest Owls|r and|r |cRXP_ENEMY_Goldwing Hawks|r
+    .complete 29147,1 -- Alpine Songbird gathered (12)
+    .target +Alpine Songbird
+    .complete 29147,2 -- Forest Owl gathered (5)
+    .target +Forest Owl
+    .complete 29147,3 -- Goldwing Hawk gathered (2)
+    .target +Goldwing Hawk
+step
+    .isOnQuest 29125
+    #loop
+    .goto 198,37.32,54.52,70,0
+    .goto 198,40.87,55.93,70,0
+    .goto 198,36.43,60.73,70,0
+    .goto 198,33.45,64.19,70,0
+    >>Stand infront of a |cRXP_FRIENDLY_Spirit of Malorne|r
+    >>|cRXP_WARN_These are the ghost deers that are randomly charging around|r
+    .complete 29125,1 --Spirit of Malorne captured (3)
+step
+    #completewith next
+    .goto 198,14.310,33.203
+    .vehicle >> Click the |cRXP_PICK_Climbing Tree|r to begin climbing it
+    .target Climbing Tree
+    .isOnQuest 29161
+step
+    .goto 198,14.310,33.203
+    >>Click a |cRXP_FRIENDLY_Hyjal Bear Cub|r while on the tree
+    .collect 54439,1
+    .target Hyjal Bear Cub
+    .isOnQuest 29161
+step
+    .isOnQuest 29161
+    .goto 198,14.310,33.203
+    *|cRXP_WARN_Cast|r |T450907:0|t[Climb Up] (1) |cRXP_WARN_until you're at the top, aim the arrow at the trampoline beside |cRXP_FRIENDLY_Keeper Taldros|r, then cast|r |T446127:0|t[Chuck-a-bear] (4)|cRXP_WARN_. Cast|r |T450905:0|t[Climb Down] (2) |cRXP_WARN_and repeat the process|r
+    .complete 29161,1 --6/6 Hyjal Bear Cubs Rescued
+step
+    .isQuestComplete 29161
+    .exitvehicle >> |cRXP_WARN_Cast|r |T450905:0|t[Climb Down] (2) |cRXP_WARN_to exit the tree|r
+step
+    #optional
+    .isQuestComplete 29161
+    .vehicle >> |cRXP_WARN_Cast|r |T450905:0|t[Climb Down] (2) |cRXP_WARN_to exit the tree|r
+step
+    #optional
+    .isQuestComplete 29161
+    .exitvehicle >> |cRXP_WARN_Cast|r |T450905:0|t[Climb Down] (2) |cRXP_WARN_to exit the tree|r
+step
+    #optional
+    .isQuestComplete 29161
+    .vehicle >> |cRXP_WARN_Cast|r |T450905:0|t[Climb Down] (2) |cRXP_WARN_to exit the tree|r
+step
+    #optional
+    .isQuestComplete 29161
+    .exitvehicle >> |cRXP_WARN_Cast|r |T450905:0|t[Climb Down] (2) |cRXP_WARN_to exit the tree|r
+step
+    #optional
+    .isQuestComplete 29161
+    .vehicle >> |cRXP_WARN_Cast|r |T450905:0|t[Climb Down] (2) |cRXP_WARN_to exit the tree|r
+step
+    #optional
+    .isQuestComplete 29161
+    .exitvehicle >> |cRXP_WARN_Cast|r |T450905:0|t[Climb Down] (2) |cRXP_WARN_to exit the tree|r
+step
+    .isOnQuest 29161
+    >>Click the Quest Turn in Pop-Up in your Questlog.
+    .turnin 29161 >>Turn in Those Bears Up There
+    .accept 29162 >>Accept Nature's Blessing
+step
+    .isQuestTurnedIn 29161
+    >>Click the Quest Turn in Pop-Up in your Questlog.
+    .accept 29162 >>Accept Nature's Blessing
+step
+    .isOnQuest 29125
+    >>Click the Quest Turn in Pop-Up in your Questlog.
+    .turnin 29125 >>Turn in Between the Trees
+    .accept 29126 >>Accept The Power of Malorne
+step
+    .isQuestTurnedIn 29125
+    >>Click the Quest Turn in Pop-Up in your Questlog.
+    .accept 29126 >>Accept The Power of Malorne
+step
+    .isOnQuest 29147
+    >>Click the Quest Turn in Pop-Up in your Questlog.
+    .turnin 29147 >>Turn in Call the Flock
+    .accept 29148 >>Accept Wings Aflame
+step
+    .isQuestTurnedIn 29147
+    >>Click the Quest Turn in Pop-Up in your Questlog.
+    .accept 29148 >>Accept Wings Aflame
+step
+    .isOnQuest 29164
+    >>Click the Quest Turn in Pop-Up in your Questlog.
+    .turnin 29164 >>Turn in Perfecting Your Howl
+    .accept 29165 >>Accept The Call of the Pack
+step
+    .isQuestTurnedIn 29164
+    >>Click the Quest Turn in Pop-Up in your Questlog.
+    .accept 29165 >>Accept The Call of the Pack
+step
+    .isOnQuest 29101
+    >>Click the Quest Turn in Pop-Up in your Questlog.
+    .turnin 29101 >>Turn in Punting Season
+    .accept 29122 >>Accept Echoes of Nemesis
+step
+    .isQuestTurnedIn 29101
+    >>Click the Quest Turn in Pop-Up in your Questlog.
+    .accept 29122 >>Accept Echoes of Nemesis
+step
+    #completewith next
+    .isOnQuest 29162
+    .goto 198/1,-1500.700,4929.300
+    .cast 97517 >> |cRXP_WARN_Use the|r |T134093:0|t[Emerald of Aessina] |cRXP_WARN_to summon|r |cRXP_ENEMY_Pyrachnis|r
+    .use 69232
+step
+    .isOnQuest 29162
+    .goto 198/1,-1500.700,4929.300
+    .use 69232 >> Kill |cRXP_ENEMY_Pyrachnis|r
+    >>|cRXP_WARN_Use the|r |T134093:0|t[Emerald of Aessina] |cRXP_WARN_to also remove the|r |T136016:0|t[Boiling Poison Bolt] |cRXP_WARN_debuff off yourself which |cRXP_ENEMY_Pyrachnis|r applies|r
+    .complete 29162,1 --|Pyrachnis slain: 1/1
+    .mob Pyrachnis
+step
+    #completewith next
+    .isOnQuest 29126
+    .goto 198,41.667,56.130
+    .cast 97012 >> |cRXP_WARN_Use the|r |T135139:0|t[Guardian's Staff] |cRXP_WARN_at the |cRXP_PICK_Pile of Ash|r to summon|r |cRXP_ENEMY_Galenges|r
+    .use 68997
+step
+    .goto 198,41.667,56.130
+    .isOnQuest 29126
+    .use 68997 >> Kill |cRXP_ENEMY_Galenges|r
+    .complete 29126,1 -- Galenges slain (1)
+    .mob Galenges
+step
+    .isOnQuest 29148
+    #completewith next
+    .goto 198/1,-1500.700,4929.300
+    .cast 97324 >> |cRXP_WARN_Use the|r |T135992:0|t[Quill of the Bird-Queen] |cRXP_WARN_near the western flame portal to summon|r |cRXP_ENEMY_Millagazor|r
+    .use 69212
+step
+    .isOnQuest 29148
+    .goto 198/1,-1500.700,4929.300
+    .use 69212 >> Kill |cRXP_ENEMY_Millagazor|r
+    .complete 29148,1 -- Millagazor slain (1)
+    .mob Millagazor
+step
+    .isOnQuest 29165
+    #completewith next
+    .goto 198,41.667,56.130
+    .cast 97498 >> |cRXP_WARN_Use the|r |T134298:0|t[Fang of the Wolf] |cRXP_WARN_to summon|r |cRXP_ENEMY_Lylagar|r
+    .use 69225
+step
+    .isOnQuest 29165
+    .goto 198,41.667,56.130
+    .use 69225 >> Kill |cRXP_ENEMY_Lylagar|r
+    .complete 29165,1 -- Lylagar slain (1)
+    .mob Lylagar
+step
+    .isOnQuest 29122
+    #completewith next
+    .goto 198,24.014,55.803
+    .gossip 52425,0 >>Talk to |cRXP_FRIENDLY_Tooga|r to summon |cRXP_ENEMY_Nemesis|r
+    .skipgossip
+    .target Tooga
+step
+    #label KillNemesis
+    .isOnQuest 29122
+    .goto 198,24.760,55.259
+    >>Kill |cRXP_ENEMY_Nemesis|r
+    >>|cRXP_WARN_Stand under |cRXP_FRIENDLY_Tooga's|r shell to protect you from|r |cRXP_ENEMY_Nemesis'|r |T135830:0|t[Molten Fury] |cRXP_WARN_cast|r
+    .complete 29122,1 -- Nemesis slain (1)
+    .target Tooga
+    .mob Nemesis
+step
+    .isOnQuest 29166
+    #loop
+    .goto 198,29.53,56.21,70,0
+    .goto 198,36.15,52.44,70,0
+    .goto 198,35.94,58.80,70,0
+    .goto 198,24.27,62.12,70,0
+    >>Loot the |cRXP_LOOT_Blueroot Vines|r on the ground
+    .complete 29166,1
+step
+    .isOnQuest 29123
+    #loop
+    .goto 198,23.06,59.99,0
+    .goto 198,16.01,50.51,0
+    .goto 198,10.29,36.11,0
+    .goto 198,23.06,59.99,70,0
+    .goto 198,19.29,58.54,70,0
+    .goto 198,16.01,50.51,70,0
+    .goto 198,14.98,43.10,70,0
+    .goto 198,10.29,36.11,70,0
+    >>Kill the |cRXP_ENEMY_Invaders from the Firelands|r
+    .complete 29123,1
+    .mob Flame Terror
+    .mob Brimstone Hound
+    .mob Scarred Acolyte
+    .mob Charred Invader
+step
+    .isOnQuest 29149
+    #loop
+    .goto 198,23.06,59.99,0
+    .goto 198,16.01,50.51,0
+    .goto 198,10.29,36.11,0
+    .goto 198,23.06,59.99,70,0
+    .goto 198,19.29,58.54,70,0
+    .goto 198,16.01,50.51,70,0
+    .goto 198,14.98,43.10,70,0
+    .goto 198,10.29,36.11,70,0
+    >>Kill the |cRXP_ENEMY_Invaders from the Firelands|r
+    .complete 29149,1
+    .mob Flame Terror
+    .mob Brimstone Hound
+    .mob Scarred Acolyte
+    .mob Charred Invader
+step
+    .isOnQuest 29127
+    #loop
+    .goto 198,23.06,59.99,0
+    .goto 198,16.01,50.51,0
+    .goto 198,10.29,36.11,0
+    .goto 198,23.06,59.99,70,0
+    .goto 198,19.29,58.54,70,0
+    .goto 198,16.01,50.51,70,0
+    .goto 198,14.98,43.10,70,0
+    .goto 198,10.29,36.11,70,0
+    >>Kill the |cRXP_ENEMY_Invaders from the Firelands|r
+    .complete 29127,1
+    .mob Flame Terror
+    .mob Brimstone Hound
+    .mob Scarred Acolyte
+    .mob Charred Invader
+step
+    .isOnQuest 29163
+    #loop
+    .goto 198,23.06,59.99,0
+    .goto 198,16.01,50.51,0
+    .goto 198,10.29,36.11,0
+    .goto 198,23.06,59.99,70,0
+    .goto 198,19.29,58.54,70,0
+    .goto 198,16.01,50.51,70,0
+    .goto 198,14.98,43.10,70,0
+    .goto 198,10.29,36.11,70,0
+    >>Kill the |cRXP_ENEMY_Invaders from the Firelands|r
+    .complete 29163,1
+    .mob Flame Terror
+    .mob Brimstone Hound
+    .mob Scarred Acolyte
+    .mob Charred Invader
+step -- 29128 The Protectors of Hyjal
+    .isOnQuest 29128
+    #completewith FinishProtector
+    #loop
+    .goto 198,31.6,74.2,70,0
+    .goto 198,30.0,80.2,70,0
+    .goto 198,31.2,87.6,70,0
+    .goto 198,31.6,95.6,70,0
+    .goto 198,36.4,98.0,70,0
+    >>Kill |cRXP_ENEMY_Fiery Behemoths|r and |cRXP_ENEMY_Seething Pyrelords|r
+    .complete 29128,1 -- Invader slain at Sethria's Roost (6)
+    .mob Fiery Behemoth
+    .mob Seething Pyrelord
+step -- 29247 Treating the Wounds
+    .isOnQuest 29247
+    #loop
+    .goto 198,31.6,74.2,70,0
+    .goto 198,30.0,80.2,70,0
+    .goto 198,31.2,87.6,70,0
+    .goto 198,31.6,95.6,70,0
+    .goto 198,36.4,98.0,70,0
+    >>Kill |cRXP_ENEMY_Fiery Behemoths|r. Loot them for their |cRXP_LOOT_Sulfur-Laced Wrappings|r
+    .complete 29247,1 -- Sulfur-Laced Wrapping (4)
+    .mob Fiery Behemoth
+step -- 29246 Relieving the Pain
+    .isOnQuest 29246
+    #label FinishProtector
+    #loop
+    .goto 198,31.6,74.2,70,0
+    .goto 198,30.0,80.2,70,0
+    .goto 198,31.2,87.6,70,0
+    .goto 198,31.6,95.6,70,0
+    .goto 198,36.4,98.0,70,0
+    >>Kill |cRXP_ENEMY_Seething Pyrelords|r. Loot them for their |cRXP_LOOT_Flame-Wreathed Hearts|r
+    .complete 29246,1 -- Flame-Wreathed Heart (4)
+    .mob Seething Pyrelord
+step -- 29128 The Protectors of Hyjal
+    .isOnQuest 29128
+    #loop
+    .goto 198,31.6,74.2,70,0
+    .goto 198,30.0,80.2,70,0
+    .goto 198,31.2,87.6,70,0
+    .goto 198,31.6,95.6,70,0
+    .goto 198,36.4,98.0,70,0
+    >>Kill |cRXP_ENEMY_Fiery Behemoths|r and |cRXP_ENEMY_Seething Pyrelords|r
+    .complete 29128,1 -- Invader slain at Sethria's Roost (6)
+    .mob Fiery Behemoth
+    .mob Seething Pyrelord
+step -- 29248 Releasing the Pressure
+    .isOnQuest 29248
+    .goto 198,32.0,59.8,70,0
+    .goto 198,36.6,54.8,70,0
+    .goto 198,39.2,62.6,70,0
+    .goto 198,34.6,64.6,70,0
+    .goto 198,30.6,52.2,70,0
+    >>Kill |cRXP_ENEMY_Charred Flamewakers|r. Loot them for their |cRXP_LOOT_Flamewaker Scales|r
+    .complete 29248,1 -- Flamewaker Scale (100)
+    .mob Charred Flamewaker
+step
+    .isQuestComplete 29162
+    .goto 198/1,-2080.000,4439.900
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Mylune|r
+    .target Mylune
+    .dailyturnin 29162 >>Turn in Nature's Blessing
+step
+    .isQuestComplete 29122
+    .goto 198/1,-2080.000,4439.900
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Mylune|r
+    .target Mylune
+    .dailyturnin 29122 >>Turn in Echoes of Nemesis
+step
+    .isQuestComplete 29126
+    .goto 198,27.170,62.563
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Matoclaw|r
+    .target Matoclaw
+    .dailyturnin 29126 >>Turn in The Power of Malorne
+step
+    .isQuestComplete 29165
+    .goto 198,27.170,62.563
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Matoclaw|r
+    .target Matoclaw
+    .dailyturnin 29165 >>Turn in The Call of the Pack
+step
+    .isQuestComplete 29148
+    .goto 198/1,-2082.800,4424.400
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Matoclaw|r
+    .target Matoclaw
+    .dailyturnin 29148 >>Turn in Wings Aflame
+step
+    .isQuestComplete 29166
+    .goto 198/1,-2082.800,4424.400
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Matoclaw|r
+    .target Matoclaw
+    .dailyturnin 29166 >>Turn in Supplies for the Other Side
+step
+    .isQuestComplete 29123
+    .goto 198/1,-2082.800,4424.400
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Matoclaw|r
+    .target Matoclaw
+    .dailyturnin 29123 >>Turn in Rage Against the Flames
+step
+    .isQuestComplete 29149
+    .goto 198/1,-2082.800,4424.400
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Matoclaw|r
+    .target Matoclaw
+    .dailyturnin 29149 >>Turn in Rage Against the Flames
+step
+    .isQuestComplete 29127
+    .goto 198/1,-2082.800,4424.400
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Matoclaw|r
+    .target Matoclaw
+    .dailyturnin 29127 >>Turn in Rage Against the Flames
+step
+    .isQuestComplete 29163
+    .goto 198/1,-2082.800,4424.400
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Matoclaw|r
+    .target Matoclaw
+    .dailyturnin 29163 >>Turn in Rage Against the Flames
+step
+    .isQuestComplete 29246
+    .goto 198,27.527,62.515
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Dorda'en Nightweaver|r
+    .target Dorda'en Nightweaver
+    .dailyturnin 29246 >>Turn in Relieving the Pain
+step
+    .isQuestComplete 29247
+    .goto 198,27.527,62.515
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Dorda'en Nightweaver|r
+    .target Dorda'en Nightweaver
+    .dailyturnin 29247 >>Turn in Treating the Wounds
+step
+    .isQuestComplete 29248
+    .goto 198,27.527,62.515
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Dorda'en Nightweaver|r
+    .target Dorda'en Nightweaver
+    .dailyturnin 29248 >>Turn in Releasing the Pressure
+step
+    #completewith next
+    .isQuestComplete 29128
+    .goto 198,27.484,56.394
+    .zone 338 >> Go through the Portal to the Firelands
+step
+    .isQuestComplete 29294
+    .goto 338,50.7,87.3
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Avrilla|r
+    .daily 29255,29299,29257 >> Accept whichever random daily quest is offered
+    .target Avrilla
+step
+    .goto 338,48.513,86.257
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Rayne Feathersong|r 
+    .daily 29139,29143 >>Accept whichever random daily quest is offered
+    .target Rayne Feathersong
+step
+    .goto 338,45.626,86.144
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Captain Irontree|r 
+    .daily 29138 >>Accept Burn Victims
+    .target Captain Irontree
+step
+    .goto 338,45.589,85.822
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_General Taldris Moonfall|r 
+    .daily 29179 >>Accept Hostile Elements
+    .daily 29304,29141,29142,29137 >> Accept whichever random daily quest is offered
+    .target General Taldris Moonfall
+step
+    .isQuestComplete 29128
+    .goto 338,45.589,85.822
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_General Taldris Moonfall|r 
+    .dailyturnin 29128 >>Turn in The Protectors of Hyjal
+    .target General Taldris Moonfall
+step -- 29255 Embergris
+    .isOnQuest 29255
+    #sticky
+    #label Embergris
+    #loop
+    .goto 338,47.6,79.6,45,0
+    .goto 338,43.8,74.0,45,0
+    .goto 338,45.8,64.2,45,0
+    .goto 338,52.8,64.4,45,0
+    .goto 338,53.6,79.6,45,0
+    >>Kill |cRXP_ENEMY_Charred Vanquishers|r and |cRXP_ENEMY_Charred Soldiers|r. Loot them for their |cRXP_LOOT_Embergris|r
+    .complete 29255,1 -- Embergris (5)
+    .mob Charred Vanquisher
+    .mob Charred Soldier
+step -- 29299 Some Like it Hot
+    .isOnQuest 29299
+    #sticky
+    #label SomeLikeItHot
+    #loop
+    .goto 338,43.7,64.1,45,0
+    .goto 338,46.7,62.5,45,0
+    .goto 338,53.6,65.4,45,0
+    .goto 338,54.6,59.9,45,0
+    .goto 338,43.5,50.0,45,0
+    >>Kill |cRXP_ENEMY_Emberspit Scorpions|r and let the Crimson Lasher following you stand in the fire it drops when it dies.
+    .complete 29299,6 -- Help the Crimson Lasher Drink from Ember Pools (6)
+    .mob Emberspit Scorpion
+step -- 29257 Steal Magmolia
+    .isOnQuest 29257
+    #sticky
+    #label StealMagmolia
+    #loop
+    .goto 338,47.6,79.6,45,0
+    .goto 338,43.8,74.0,45,0
+    .goto 338,45.8,64.2,45,0
+    .goto 338,52.8,64.4,45,0
+    .goto 338,53.6,79.6,45,0
+    >>Loot |cRXP_LOOT_Magmolia|r on the ground.
+    .complete 29255,1 -- Magmolia (8)
+step -- 29138 Burn Victims
+    .isOnQuest 29138
+    #sticky
+    #label BurnVictims
+    #loop
+    .goto 338,47.6,79.6,45,0
+    .goto 338,43.8,74.0,45,0
+    .goto 338,45.8,64.2,45,0
+    .goto 338,52.8,64.4,45,0
+    .goto 338,53.6,79.6,45,0
+    .use 69240 >> |cRXP_WARN_Use the|r |T463860:0|t[Enchanted Salve] |cRXP_WARN_on|r |cRXP_FRIENDLY_Wounded Hyjal Defenders|r
+    .complete 29138,1 -- Wounded Hyjal Defender saved 1/1
+    .target Wounded Hyjal Defender
+step -- 29179 Hostile Elements
+    .isOnQuest 29179
+    #sticky
+    #label HostileElements
+    #loop
+    .goto 338,47.6,79.6,45,0
+    .goto 338,43.8,74.0,45,0
+    .goto 338,45.8,64.2,45,0
+    .goto 338,52.8,64.4,45,0
+    .goto 338,53.6,79.6,45,0
+    >>Kill |cRXP_ENEMY_Charred Vanquishers|r and |cRXP_ENEMY_Charred Soldiers|r
+    .complete 29179,1 -- Charred Combatant slain (8)
+    .mob Charred Vanquisher
+    .mob Charred Soldier
+step -- 29304 The Dogs of War
+    .isOnQuest 29304
+    #sticky
+    #label TheDogs
+    #loop
+    .goto 338,47.6,79.6,45,0
+    .goto 338,43.8,74.0,45,0
+    .goto 338,45.8,64.2,45,0
+    .goto 338,52.8,64.4,45,0
+    .goto 338,53.6,79.6,45,0
+    .goto 338,53.4,53.0,45,0
+    .goto 338,40.8,45.0,45,0
+    >>Kill |cRXP_ENEMY_Charhounds|r and |cRXP_ENEMY_Ancient Charhounds|r
+    .complete 29304,1 -- Ancient Charhound slain (5)
+    .mob Charhound
+    .mob Ancient Charhound
+step -- 29141 The Harder They Fall
+    .isOnQuest 29141
+    #sticky
+    #label HarderTheyFall
+    #loop
+    .goto 338,47.6,79.6,45,0
+    .goto 338,43.8,74.0,45,0
+    .goto 338,45.8,64.2,45,0
+    .goto 338,52.8,64.4,45,0
+    .goto 338,53.6,79.6,45,0
+    .goto 338,53.4,53.0,45,0
+    .goto 338,40.8,45.0,45,0
+    >>Kill |cRXP_ENEMY_Molten Behemoths|r
+    .complete 29141,1 -- Molten Behemoth slain (3)
+    .mob Molten Behemoth
+step -- 29142 Traitors Return
+    .isOnQuest 29142
+    #sticky
+    #label TraitorsReturn
+    #loop
+    .goto 338,47.6,79.6,45,0
+    .goto 338,43.8,74.0,45,0
+    .goto 338,45.8,64.2,45,0
+    .goto 338,52.8,64.4,45,0
+    .goto 338,71.0,38.6,45,0
+    >>Kill |cRXP_ENEMY_Druids of the Flame|r
+    .complete 29142,1 -- Druid of the Flame slain (3)
+    .mob Druid of the Flame
+step -- 29137 Breach in the Defenses
+    .isOnQuest 29137
+    #sticky
+    #label Breach
+    #loop
+    .goto 338,47.6,79.6,45,0
+    .goto 338,43.8,74.0,45,0
+    .goto 338,45.8,64.2,45,0
+    .goto 338,52.8,64.4,45,0
+    .goto 338,53.6,79.6,45,0
+    .goto 338,53.4,53.0,45,0
+    .goto 338,40.8,45.0,45,0
+    >>Kill |cRXP_ENEMY_Lava Bursters|r
+    .complete 29137,1 -- Lava Burster slain (5)
+    .mob Lava Burster
+step -- 29139 Aggressive Growth
+    .isOnQuest 29139
+    #sticky
+    #label AggressiveGrowth
+    #loop
+    .goto 338,47.6,79.6,45,0
+    .goto 338,43.8,74.0,45,0
+    .goto 338,45.8,64.2,45,0
+    .goto 338,52.8,64.4,45,0
+    .goto 338,53.6,79.6,45,0
+    >>Click the |cRXP_PICK_Ash Piles|r on the ground
+    .complete 29139,1 -- Smothervine planted (5)
+step -- 29143 Wisp Away
+    .isOnQuest 29143
+    #sticky
+    #label WispAway
+    #loop
+    .goto 338,47.6,79.6,45,0
+    .goto 338,43.8,74.0,45,0
+    .goto 338,45.8,64.2,45,0
+    .goto 338,52.8,64.4,45,0
+    .goto 338,53.6,79.6,45,0
+    >>|cRXP_WARN_Take the |cRXP_FRIENDLY_Hyjal Wisp|r following you to a Fire Portal|r
+    >>|cRXP_WARN_Kill the mobs that come out of it. Ensure the |cRXP_FRIENDLY_Hyjal Wisp|r doesn't die!|r
+    .complete 29143,1 -- Close a Fire Portal 1/1
+step
+    #optional
+    #requires BurnVictims
+step
+    #optional
+    #requires HostileElements
+step
+    #optional
+    #requires TheDogs
+step
+    #optional
+    #requires HarderTheyFall
+step
+    #optional
+    #requires TraitorsReturn
+step
+    #optional
+    #requires Breach
+step
+    #optional
+    #requires AggressiveGrowth
+step
+    #optional
+    #requires WispAway
+step
+    #optional
+    #requires Embergris
+step
+    #optional
+    #requires SomeLikeItHot
+step
+    #optional
+    #requires StealMagmolia
+step
+    .isQuestComplete 29255
+    .goto 338,50.7,87.3
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Avrilla|r
+    .dailyturnin 29255 >>Turn in Embergris
+    .target Avrilla
+step
+    .isQuestComplete 29299
+    .goto 338,50.7,87.3
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Avrilla|r
+    .dailyturnin 29299 >>Turn in Some Like It Hot
+    .target Avrilla
+step
+    .isQuestComplete 29257
+    .goto 338,50.7,87.3
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Avrilla|r
+    .dailyturnin 29257 >>Turn in Steal Magmolia
+    .target Avrilla
+step
+    .isQuestComplete 29139
+    .goto 338,48.513,86.257
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Rayne Feathersong|r 
+    .dailyturnin 29139 >>Turn in Aggressive Growth
+    .target Rayne Feathersong
+step
+    .isQuestComplete 29143
+    .goto 338,48.513,86.257
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Rayne Feathersong|r 
+    .dailyturnin 29143 >>Turn in Wisp Away
+    .target Rayne Feathersong
+step
+    .isQuestComplete 29179
+    .goto 338,45.589,85.822
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_General Taldris Moonfall|r 
+    .dailyturnin 29179 >>Turn in Hostile Elements
+    .target General Taldris Moonfall
+step
+    .isQuestComplete 29304
+    .goto 338,45.589,85.822
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_General Taldris Moonfall|r 
+    .dailyturnin 29304 >> Turn in The Dogs of War
+    .target General Taldris Moonfall
+step
+    .isQuestComplete 29141
+    .goto 338,45.589,85.822
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_General Taldris Moonfall|r 
+    .dailyturnin 29141 >> Turn in The Harder They Fall
+    .target General Taldris Moonfall
+step
+    .isQuestComplete 29142
+    .goto 338,45.589,85.822
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_General Taldris Moonfall|r 
+    .dailyturnin 29142 >> Turn in Traitors Return
+    .target General Taldris Moonfall
+step
+    .isQuestComplete 29137
+    .goto 338,45.589,85.822
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_General Taldris Moonfall|r 
+    .dailyturnin 29137 >> Turn in Breach in the Defenses
+    .target General Taldris Moonfall
+step
+    .isQuestComplete 29138
+    .goto 338,45.626,86.144
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Captain Irontree|r 
+    .dailyturnin 29138 >>Turn in Burn Victims
+    .target Captain Irontree
+step
+    .isQuestTurnedIn 29214
+    .goto 338,45.589,85.822
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_General Taldris Moonfall|r 
+    .daily 29205 >>Accept The Forlorn Spire
+    .target General Taldris Moonfall
+step
+    .isOnQuest 29205
+    .goto 338,54,68,10,0
+    .goto 338,59,64,10,0
+    .goto 338,66,65
+    >>Escort and protect the |cRXP_FRIENDLY_Shadow Warden|r through the fire
+    >>Kill the |cRXP_ENEMY_Pyrelord|r at the end
+    >>Talk to |cRXP_FRIENDLY_Deldren Ravenelm|r just before the fires if a |cRXP_FRIENDLY_Windcaller|r is not present
+    .complete 29205,1 -- Druid Assault Group protected 1/1
+    .mob Flamewatch Sentinel
+    .mob Pyrelord
+    .target Deldren Ravenelm
+    .skipgossip
+step
+    .isQuestTurnedIn 29214
+    .goto 338,64.9,67.3
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Marin Bladewing|r
+    .dailyturnin 29205 >>Turn in The Forlorn Spire
+    .daily 29192,29211 >>Accept Whichever Random Daily Quest is Offered
+    .target Marin Bladewing
+step
+    .isQuestTurnedIn 29214
+    .goto 338,66.1,63.9
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Deldren Ravenelm|r
+    .daily 29159 >>Accept Pyroachnophobia
+    .daily 29189,29160 >>Accept Whichever Random Daily Quest is Offered
+    .target Deldren Ravenelm
+
+
+step -- 29192 The Wardens are Watching
+    .isOnQuest 29192
+    #sticky
+    #label TheWardensAreWatching
+    .goto 338,70.9,38.5
+    >>Attack a |cRXP_ENEMY_Druid of the Flame|r and lower its health to 30%. Then let the |cRXP_FRIENDLY_Shadow Warden|r following you lay a trap. Then drag the |cRXP_ENEMY_Druid of the Flame|r over it to capture it and get credit for this quest.
+    .complete 29192,1 -- Warden's Core (5)
+    .mob Druid of the Flame
+step -- 29211 Solar Core Destruction
+    .isOnQuest 29211
+    #sticky
+    #label SolarCoreDestruction
+    .goto 338,70.9,31
+    >>Run up to the |cRXP_ENEMY_Solar Core|r and activate it and you will be blasted away. You do not need to kill any |cRXP_FRIENDLY_Druids of the Flame|r.
+    .complete 29211,1 -- Solar Core (5)
+step -- 29159 Pyroachnophobia
+    .isOnQuest 29159
+    #sticky
+    #label Pyroachnophobia
+    #loop
+    .goto 338,68.4,55.3,70,0
+    .goto 338,63.2,38.9,70,0
+    .goto 338,59.8,42.7,70,0
+    .goto 338,63.3,58.2,70,0
+    >>Kill the |cRXP_ENEMY_Cinderweb Creepers|r and |cRXP_ENEMY_Cinderweb Spinners|r
+    .complete 29159,1 -- Cinderweb spider slain (8)
+    .mob Cinderweb Creeper
+    .mob Cinderweb Spinner
+step -- 29189 Wicked Webs
+    .isOnQuest 29189
+    #sticky
+    #label WickedWebs
+    #loop
+    .goto 338,68.4,55.3,70,0
+    .goto 338,63.2,38.9,70,0
+    .goto 338,59.8,42.7,70,0
+    .goto 338,63.3,58.2,70,0
+    >>Kill the |cRXP_ENEMY_Cinderweb Cocoons|r to free the victims.
+    .complete 29189,1 -- Cinderweb cocoon slain (8)
+step -- 29160 Egg-stinction
+    .isOnQuest 29160
+    #sticky
+    #label Eggstinction
+    #loop
+    .goto 338,65,56,70,0
+    .goto 338,67,41,70,0
+    >>Climb the pillars and collect the |cRXP_LOOT_Cinderweb Eggs|r from the ground
+    .complete 29160,1 -- Cinderweb Egg (20)
+
+step
+    #optional
+    #requires TheWardensAreWatching
+step
+    #optional
+    #requires SolarCoreDestruction
+step
+    #optional
+    #requires Pyroachnophobia
+step
+    #optional
+    #requires WickedWebs
+step
+    #optional
+     requires Eggstinction
+step
+    .isQuestComplete 29159
+    .goto 338,66.1,63.9
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Deldren Ravenelm|r
+    .dailyturnin 29159 >>Turn in Pyroachnophobia
+    .target Deldren Ravenelm
+step
+    .isQuestComplete 29189
+    .goto 338,66.1,63.9
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Deldren Ravenelm|r
+    .dailyturnin 29189 >>Turn in Wicked Webs
+    .target Deldren Ravenelm
+step
+    .isQuestComplete 29160
+    .goto 338,66.1,63.9
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Deldren Ravenelm|r
+    .dailyturnin 29160 >>Turn in Egg-stinction
+    .target Deldren Ravenelm
+step
+    .isQuestComplete 29211
+    .goto 338,64.9,67.3
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Marin Bladewing|r
+    .dailyturnin 29211 >>Turn in Solar Core Destruction
+    .target Marin Bladewing
+step
+    .isQuestComplete 29192
+    .goto 338,64.9,67.3
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Marin Bladewing|r
+    .dailyturnin 29192 >>Turn in The Wardens are Watching
+    .daily 29210 >>Accept Enduring the Heat
+    .target Marin Bladewing
+
+step
+    #completewith next
+    .goto 338,57.2,50.9
+    .subzone 5741 >> Head into the Igneous Depths
+step -- Enduring the Heat
+    .isOnQuest 29210
+    #loop
+    .goto 338,61.6,52.9,10,0 -- front
+    .goto 338,60.5,60.0,10,0 -- front right
+    .goto 338,64.73,59.26,10,0 -- overpass
+    .goto 338,64.16,66.06,10,0 -- right
+    .goto 338,68.14,66.48,10,0 -- thermal vent
+    .goto 338,68.86,58.33,10,0 -- back center
+    .goto 338,66.37,52.24,10,0 -- left
+    .goto 338,61.42,48.47,10,0 -- front left
+    >>Head into the cave and click on each of the eight blue runes on the ground
+    .complete 29210,2 -- All flame runes destroyed
+
+step
+    .isQuestComplete 29210
+    .goto 338,57.7,49.5
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Theresa Barkskin|r
+    .dailyturnin 29210 >>Turn in Enduring the Heat
+    .target Theresa Barkskin
+
+step
+    #label ShadowWardensEnd
+    +|cRXP_WARN_You have completed all the available daily quests for today. Reload this same guide tomorrow (|r|cRXP_ENEMY_2.5|r - The Molten Front + Shadow Wardens|cRXP_WARN_) to continue completing the daily quests until you have acquired enough|r |T513195:0|t[Marks of the World Tree]
 ]])

--- a/Guides/Dailies/Cataclysm/Molten Front.lua
+++ b/Guides/Dailies/Cataclysm/Molten Front.lua
@@ -2115,7 +2115,7 @@ step
     .goto 198,27.484,56.394
     .zone 338 >> Go through the Portal to the Firelands
 step
-    .isQuestComplete 29294
+    .isQuestTurnedIn 29214
     .goto 338,50.7,87.3
     >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Avrilla|r
     .daily 29255,29299,29257 >> Accept whichever random daily quest is offered
@@ -2167,7 +2167,7 @@ step -- 29299 Some Like it Hot
     .goto 338,54.6,59.9,45,0
     .goto 338,43.5,50.0,45,0
     >>Kill |cRXP_ENEMY_Emberspit Scorpions|r and let the Crimson Lasher following you stand in the fire it drops when it dies.
-    .complete 29299,6 -- Help the Crimson Lasher Drink from Ember Pools (6)
+    .complete 29299,1 -- Help the Crimson Lasher Drink from Ember Pools (6)
     .mob Emberspit Scorpion
 step -- 29257 Steal Magmolia
     .isOnQuest 29257
@@ -3203,7 +3203,7 @@ step
     .goto 198,27.484,56.394
     .zone 338 >> Go through the Portal to the Firelands
 step
-    .isQuestComplete 29294
+    .isQuestTurnedIn 29214
     .goto 338,50.7,87.3
     >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Avrilla|r
     .daily 29255,29299,29257 >> Accept whichever random daily quest is offered
@@ -3255,7 +3255,7 @@ step -- 29299 Some Like it Hot
     .goto 338,54.6,59.9,45,0
     .goto 338,43.5,50.0,45,0
     >>Kill |cRXP_ENEMY_Emberspit Scorpions|r and let the Crimson Lasher following you stand in the fire it drops when it dies.
-    .complete 29299,6 -- Help the Crimson Lasher Drink from Ember Pools (6)
+    .complete 29299,1 -- Help the Crimson Lasher Drink from Ember Pools (6)
     .mob Emberspit Scorpion
 step -- 29257 Steal Magmolia
     .isOnQuest 29257
@@ -3560,7 +3560,7 @@ step -- 29160 Egg-stinction
     #loop
     .goto 338,65,56,70,0
     .goto 338,67,41,70,0
-    >>Climb the pillars and collect the |cRXP_LOOT_Cinderweb Eggs|r from the ground
+    >>Collect the |cRXP_LOOT_Cinderweb Eggs|r from the ground and on the pillars. You can attack the |cRXP_ENEMY_Cinderweb Spinners|r on the pillars to have them pull you towards them. If spiders get on you, jump multiple times to shake them off.
     .complete 29160,1 -- Cinderweb Egg (20)
 
 step
@@ -3607,9 +3607,12 @@ step
     .goto 338,64.9,67.3
     >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Marin Bladewing|r
     .dailyturnin 29192 >>Turn in The Wardens are Watching
+    .target Marin Bladewing
+step
+    .goto 338,64.9,67.3
+    >>|Tinterface/worldmap/chatbubble_64grey.blp:20|tTalk to |cRXP_FRIENDLY_Marin Bladewing|r
     .daily 29210 >>Accept Enduring the Heat
     .target Marin Bladewing
-
 step
     #completewith next
     .goto 338,57.2,50.9
@@ -3620,8 +3623,8 @@ step -- Enduring the Heat
     .goto 338,61.6,52.9,10,0 -- front
     .goto 338,60.5,60.0,10,0 -- front right
     .goto 338,64.73,59.26,10,0 -- overpass
-    .goto 338,64.16,66.06,10,0 -- right
     .goto 338,68.14,66.48,10,0 -- thermal vent
+    .goto 338,64.16,66.06,10,0 -- right
     .goto 338,68.86,58.33,10,0 -- back center
     .goto 338,66.37,52.24,10,0 -- left
     .goto 338,61.42,48.47,10,0 -- front left


### PR DESCRIPTION
Note that this doesn't add the quests to actually get the shadow wardens quests complete, but if you chose it then it should work. Also, it adds the singular daily Shadow Wardens quest that is available to both Shadow Wardens and Druids to the 2.5 - Druids guide.