### PR TITLE
Add option for 0 map pins

### DIFF
--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -2958,7 +2958,7 @@ function addon.settings:CreateAceOptionsPanel()
                         type = "range",
                         width = optionsWidth,
                         order = 5.4,
-                        min = 1,
+                        min = 0,
                         max = 20,
                         step = 1,
                         set = function(info, value)

--- a/map.lua
+++ b/map.lua
@@ -835,6 +835,8 @@ end
 
 -- Generate pins using the current guide's steps, then add the pins to the world map
 local function addWorldMapPins()
+	if addon.settings.profile.numMapPins == 0 then return end
+
     -- Calculate which pins should be on the world map
     local pins = generatePins(addon.currentGuide.steps, addon.settings.profile.numMapPins,
                               RXPCData.currentStep, false)


### PR DESCRIPTION
Currently it's not possible to completely disable pins in the world map. This PR adds the option to set the amount of map pins to 0, essentially disabling the pins.