### PR TITLE
Add optional talent support

### DIFF
--- a/Communications.lua
+++ b/Communications.lua
@@ -699,7 +699,25 @@ function addon.comms:ConfirmChoice(lookup, prompt, confirmCallback, payload)
         text = prompt,
         button1 = _G.YES,
         button2 = _G.NO,
-        OnAccept = function() confirmCallback(payload) end,
+        OnAccept = function()
+            if confirmCallback then
+                confirmCallback(payload)
+            end
+        end,
+        timeout = 0,
+        whileDead = 1,
+        hideOnEscape = 1,
+        showAlert = 1
+    }
+
+    _G.StaticPopup_Show(lookup)
+end
+
+function addon.comms:PopupNotification(lookup, prompt)
+
+    StaticPopupDialogs[lookup] = {
+        text = prompt,
+        button1 = _G.OKAY,
         timeout = 0,
         whileDead = 1,
         hideOnEscape = 1,

--- a/Guides/Talents/classic-warrior.lua
+++ b/Guides/Talents/classic-warrior.lua
@@ -152,18 +152,23 @@ level -- Deep Wounds Rank 3
 
 level -- Axe Specialization Rank 1
 	.talent 1,5,1,1
+    #optional
 
 level -- Axe Specialization Rank 2
 	.talent 1,5,1,2
+    #optional
 
 level -- Axe Specialization Rank 3
 	.talent 1,5,1,3
+    #optional
 
 level -- Axe Specialization Rank 4
 	.talent 1,5,1,4
+    #optional
 
 level -- Axe Specialization Rank 5
 	.talent 1,5,1,5
+    #optional
 
 level -- Impale Rank 1
 	.talent 1,4,3,1
@@ -533,18 +538,23 @@ level -- Deep Wounds Rank 3
 
 level -- Axe Specialization Rank 1
 	.talent 1,5,1,1
+    #optional
 
 level -- Axe Specialization Rank 2
 	.talent 1,5,1,2
+    #optional
 
 level -- Axe Specialization Rank 3
 	.talent 1,5,1,3
+    #optional
 
 level -- Axe Specialization Rank 4
 	.talent 1,5,1,4
+    #optional
 
 level -- Axe Specialization Rank 5
 	.talent 1,5,1,5
+    #optional
 
 level -- Impale Rank 1
 	.talent 1,4,3,1

--- a/Guides/Talents/classic-warrior.lua
+++ b/Guides/Talents/classic-warrior.lua
@@ -150,25 +150,35 @@ level -- Sweeping Strikes
 level -- Deep Wounds Rank 3
 	.talent 1,3,3,3
 
-level -- Axe Specialization Rank 1
-	.talent 1,5,1,1
+level -- Weapon Specialization (Rank 1)
     #optional
+    .talent 1,5,1,1 -- Axe Specialization Rank 1
+    .talent 1,5,3,1 -- Mace Specialization (Rank 1)
+    .talent 1,5,4,1 -- Sword Specialization (Rank 1)
 
-level -- Axe Specialization Rank 2
-	.talent 1,5,1,2
+level -- Weapon Specialization (Rank 2)
     #optional
+    .talent 1,5,1,2 -- Axe Specialization Rank 2
+    .talent 1,5,3,2 -- Mace Specialization (Rank 2)
+    .talent 1,5,4,1 -- Sword Specialization (Rank 2)
 
-level -- Axe Specialization Rank 3
-	.talent 1,5,1,3
+level -- Weapon Specialization (Rank 3)
     #optional
+    .talent 1,5,1,3 -- Axe Specialization Rank 3
+    .talent 1,5,3,3 -- Mace Specialization (Rank 3)
+    .talent 1,5,4,1 -- Sword Specialization (Rank 3)
 
-level -- Axe Specialization Rank 4
-	.talent 1,5,1,4
+level -- Weapon Specialization (Rank 4)
     #optional
+    .talent 1,5,1,4 -- Axe Specialization Rank 4
+    .talent 1,5,3,4 -- Mace Specialization (Rank 4)
+    .talent 1,5,4,1 -- Sword Specialization (Rank 4)
 
-level -- Axe Specialization Rank 5
-	.talent 1,5,1,5
+level -- Weapon Specialization (Rank 5)
     #optional
+    .talent 1,5,1,5 -- Axe Specialization Rank 5
+    .talent 1,5,3,5 -- Mace Specialization (Rank 5)
+    .talent 1,5,4,1 -- Sword Specialization (Rank 5)
 
 level -- Impale Rank 1
 	.talent 1,4,3,1
@@ -536,25 +546,35 @@ level -- Sweeping Strikes
 level -- Deep Wounds Rank 3
 	.talent 1,3,3,3
 
-level -- Axe Specialization Rank 1
-	.talent 1,5,1,1
+level -- Weapon Specialization (Rank 1)
     #optional
+    .talent 1,5,1,1 -- Axe Specialization Rank 1
+    .talent 1,5,3,1 -- Mace Specialization (Rank 1)
+    .talent 1,5,4,1 -- Sword Specialization (Rank 1)
 
-level -- Axe Specialization Rank 2
-	.talent 1,5,1,2
+level -- Weapon Specialization (Rank 2)
     #optional
+    .talent 1,5,1,2 -- Axe Specialization Rank 2
+    .talent 1,5,3,2 -- Mace Specialization (Rank 2)
+    .talent 1,5,4,1 -- Sword Specialization (Rank 2)
 
-level -- Axe Specialization Rank 3
-	.talent 1,5,1,3
+level -- Weapon Specialization (Rank 3)
     #optional
+    .talent 1,5,1,3 -- Axe Specialization Rank 3
+    .talent 1,5,3,3 -- Mace Specialization (Rank 3)
+    .talent 1,5,4,1 -- Sword Specialization (Rank 3)
 
-level -- Axe Specialization Rank 4
-	.talent 1,5,1,4
+level -- Weapon Specialization (Rank 4)
     #optional
+    .talent 1,5,1,4 -- Axe Specialization Rank 4
+    .talent 1,5,3,4 -- Mace Specialization (Rank 4)
+    .talent 1,5,4,1 -- Sword Specialization (Rank 4)
 
-level -- Axe Specialization Rank 5
-	.talent 1,5,1,5
+level -- Weapon Specialization (Rank 5)
     #optional
+    .talent 1,5,1,5 -- Axe Specialization Rank 5
+    .talent 1,5,3,5 -- Mace Specialization (Rank 5)
+    .talent 1,5,4,1 -- Sword Specialization (Rank 5)
 
 level -- Impale Rank 1
 	.talent 1,4,3,1

--- a/Guides/Talents/tbc-rogue.lua
+++ b/Guides/Talents/tbc-rogue.lua
@@ -100,21 +100,33 @@ level -- Aggression (Rank 3)
 level -- Adrenaline Rush
     .talent 2,7,2,1
 
-level -- Vitality (Rank 1)
-    #optional -- TODO Sabre
-    .talent 2,7,1,1
-
-level -- Vitality (Rank 2)
+level
     #optional
-    .talent 2,7,1,2
+    .talent 2,7,1,1 -- Vitality (Rank 1)
+    .talent 2,5,1,1 -- Mace Specialization (Rank 1)
+    .talent 2,5,3,1 -- Sword Specialization (Rank 1)
+    .talent 2,5,4,1 -- Fist Weapon Specialization (Rank 1)
 
-level -- Endurance (Rank 1)
+level
     #optional
-    .talent 2,3,1,1
+    .talent 2,7,1,2 -- Vitality (Rank 2)
+    .talent 2,5,1,2 -- Mace Specialization (Rank 2)
+    .talent 2,5,3,2 -- Sword Specialization (Rank 2)
+    .talent 2,5,4,2 -- Fist Weapon Specialization (Rank 2)
 
-level -- Endurance (Rank 2)
+level
     #optional
-    .talent 2,3,1,2
+    .talent 2,3,1,1 -- Endurance (Rank 1)
+    .talent 2,5,1,3 -- Mace Specialization (Rank 3)
+    .talent 2,5,3,3 -- Sword Specialization (Rank 3)
+    .talent 2,5,4,3 -- Fist Weapon Specialization (Rank 3)
+
+level
+    #optional
+    .talent 2,3,1,2 -- Endurance (Rank 2)
+    .talent 2,5,1,4 -- Mace Specialization (Rank 4)
+    .talent 2,5,3,4 -- Sword Specialization (Rank 4)
+    .talent 2,5,4,4 -- Fist Weapon Specialization (Rank 4)
 
 level -- Combat Potency (Rank 1)
     .talent 2,8,3,1

--- a/Guides/Talents/tbc-warrior.lua
+++ b/Guides/Talents/tbc-warrior.lua
@@ -70,25 +70,35 @@ level -- Two-Handed Weapon Specialization (Rank 5)
 level -- Death Wish
     .talent 1,5,2,1
 
-level -- Poleaxe Specialization (Rank 1)
-    .talent 1,5,1,1
+level -- Weapon Specialization (Rank 1)
     #optional
+    .talent 1,5,1,1 -- Poleaxe Specialization (Rank 1)
+    .talent 1,5,3,1 -- Mace Specialization (Rank 1)
+    .talent 1,5,4,1 -- Sword Specialization (Rank 1)
 
-level -- Poleaxe Specialization (Rank 2)
-    .talent 1,5,1,2
+level -- Weapon Specialization (Rank 2)
     #optional
+    .talent 1,5,1,2 -- Poleaxe Specialization (Rank 2)
+    .talent 1,5,3,2 -- Mace Specialization (Rank 2)
+    .talent 1,5,4,2 -- Sword Specialization (Rank 2)
 
-level -- Poleaxe Specialization (Rank 3)
-    .talent 1,5,1,3
+level -- Weapon Specialization (Rank 3)
     #optional
+    .talent 1,5,1,3 -- Poleaxe Specialization (Rank 3)
+    .talent 1,5,3,3 -- Mace Specialization (Rank 3)
+    .talent 1,5,4,3 -- Sword Specialization (Rank 3)
 
-level -- Poleaxe Specialization (Rank 4)
-    .talent 1,5,1,4
+level -- Weapon Specialization (Rank 4)
     #optional
+    .talent 1,5,1,4 -- Poleaxe Specialization (Rank 4)
+    .talent 1,5,3,4 -- Mace Specialization (Rank 4)
+    .talent 1,5,4,4 -- Sword Specialization (Rank 4)
 
-level -- Poleaxe Specialization (Rank 5)
-    .talent 1,5,1,5
+level -- Weapon Specialization (Rank 5)
     #optional
+    .talent 1,5,1,5 -- Poleaxe Specialization (Rank 5)
+    .talent 1,5,3,5 -- Mace Specialization (Rank 5)
+    .talent 1,5,4,5 -- Sword Specialization (Rank 5)
 
 level -- Deep Wounds (Rank 3)
     .talent 1,3,3,3

--- a/Talents.lua
+++ b/Talents.lua
@@ -518,21 +518,28 @@ function addon.talents.functions.talent(element, validate, optional)
                 GetTalentInfo(talentData.tab, talentIndex)
         end
 
+        -- TODO if more than one .talent in a step without #optional, error
+        -- TODO user input timing, noop prompt informing of action/options
+        if optional then
+            -- Avoid blocking on user action if talent exists in any optional blocks
+            if previewRankOrRank == talentData.rank then
+                addon.comms.PrettyPrint("%s - (%s) %s (%s %d)",
+                                    _G.TRADE_SKILLS_LEARNED_TAB,
+                                    _G.COMMUNITIES_CHANNEL_DESCRIPTION_INSTRUCTIONS,
+                                    name, _G.RANK, talentData.rank)
+                -- Handle in level step processing, if return value is rank from at least one optional step, continue
+                return true
+            end
+            -- Return -1 if not selected, check upstream to verify at least one #optional step talent chosen
+            return -1
+        end
+
         if previewRankOrRank < talentData.rank then
             if addon.game == "CLASSIC" then -- Classic doesn't have Preview Talents
                 tempData = {talentData.tab, talentIndex, name}
 
-                if optional then
-                    -- TODO user input timing, noop prompt informing of action/options
-                    -- TODO handle replaying, avoid blocking on user action if talent exists in any optional blocks
-                    addon.comms.PrettyPrint("%s - (%s) %s (%s %d)",
-                                            _G.TRADE_SKILLS_LEARNED_TAB,
-                                            _G.COMMUNITIES_CHANNEL_DESCRIPTION_INSTRUCTIONS,
-                                            name, _G.RANK, talentData.rank)
-                else
-                    addon.comms:ConfirmChoice("RXPTalentPrompt", fmt(_G.CONFIRM_LEARN_TALENT, name),
+                addon.comms:ConfirmChoice("RXPTalentPrompt", fmt(_G.CONFIRM_LEARN_TALENT, name),
                                               learnClassicTalent, tempData)
-                end
 
                 -- Stop as soon as first learning prompt, not a blocking dialog
                 return -1
@@ -550,7 +557,7 @@ function addon.talents.functions.talent(element, validate, optional)
 
                 addon.comms.PrettyPrint("%s - %s (%s %d)", _G.PREVIEW, name,
                                         _G.RANK, talentData.rank)
-            else -- TBC/Wrath/Cata
+            else -- TBC/Wrath/Cata, not previewed
                 -- TODO if optional
                 if LearnTalent(talentData.tab, talentIndex) then
                     addon.comms.PrettyPrint("%s - %s (%s %d)",

--- a/Talents.lua
+++ b/Talents.lua
@@ -12,18 +12,14 @@ local EasyMenu = function(...)
     end
 end
 
-local fmt, sgmatch, strsplittable, strjoin = string.format, string.gmatch,
-                                             strsplittable, string.join
+local fmt, sgmatch, strsplittable, strjoin = string.format, string.gmatch, strsplittable, string.join
 local tonumber = tonumber
 local tinsert, tsort = tinsert, table.sort
 local UnitLevel = UnitLevel
-local GetPetTalentTree, GetUnspentTalentPoints,
-      GetGroupPreviewTalentPointsSpent, AddPreviewTalentPoints,
-      UnitCharacterPoints = _G.GetPetTalentTree, _G.GetUnspentTalentPoints,
-                            _G.GetGroupPreviewTalentPointsSpent,
+local GetPetTalentTree, GetUnspentTalentPoints, GetGroupPreviewTalentPointsSpent, AddPreviewTalentPoints,
+      UnitCharacterPoints = _G.GetPetTalentTree, _G.GetUnspentTalentPoints, _G.GetGroupPreviewTalentPointsSpent,
                             _G.AddPreviewTalentPoints, _G.UnitCharacterPoints
-local PanelTemplates_GetSelectedTab, PlayerTalentFrame =
-    _G.PanelTemplates_GetSelectedTab, _G.PlayerTalentFrame
+local PanelTemplates_GetSelectedTab, PlayerTalentFrame = _G.PanelTemplates_GetSelectedTab, _G.PlayerTalentFrame
 local BackdropTemplate = BackdropTemplateMixin and "BackdropTemplate"
 
 local L = addon.locale.Get
@@ -96,8 +92,7 @@ local function buildTalentGuidesMenu()
             if guide.pet == GetPetTalentTree() then
                 tinsert(menu, {
                     text = guide.name,
-                    tooltipTitle = fmt("%s: %s", _G.LEVEL_RANGE,
-                                       guide.levelRange),
+                    tooltipTitle = fmt("%s: %s", _G.LEVEL_RANGE, guide.levelRange),
                     notCheckable = 1,
                     disabled = disabled,
                     tooltipText = invalidReason,
@@ -112,8 +107,7 @@ local function buildTalentGuidesMenu()
             end
         end
     else
-        tinsert(menu,
-                {text = L("Available Guides"), isTitle = 1, notCheckable = 1})
+        tinsert(menu, {text = L("Available Guides"), isTitle = 1, notCheckable = 1})
 
         for key, guide in pairs(addon.talents.guides) do
 
@@ -140,9 +134,7 @@ local function buildTalentGuidesMenu()
                 func = function(_, arg1)
                     addon.talents:UpdateSelectedGuide(arg1)
 
-                    if addon.talents:ProcessTalents('validate') then
-                        addon.talents:DrawTalents()
-                    end
+                    if addon.talents:ProcessTalents('validate') then addon.talents:DrawTalents() end
                 end
             })
         end
@@ -150,30 +142,16 @@ local function buildTalentGuidesMenu()
 
     tinsert(menu, {text = "", notCheckable = 1, isTitle = 1})
 
-    tinsert(menu, {
-        text = _G.APPLY,
-        notCheckable = 1,
-        func = function() addon.talents:ProcessTalents() end
-    })
+    tinsert(menu, {text = _G.APPLY, notCheckable = 1, func = function() addon.talents:ProcessTalents() end})
 
-    tinsert(menu, {
-        text = _G.GAMEOPTIONS_MENU,
-        notCheckable = 1,
-        func = function() addon.settings.OpenSettings() end
-    })
+    tinsert(menu, {text = _G.GAMEOPTIONS_MENU, notCheckable = 1, func = function() addon.settings.OpenSettings() end})
 
-    tinsert(menu, {
-        text = _G.CLOSE,
-        notCheckable = 1,
-        func = function(self) self:Hide() end
-    })
+    tinsert(menu, {text = _G.CLOSE, notCheckable = 1, func = function(self) self:Hide() end})
 
     return menu
 end
 
-function addon.talents:IsSupported()
-    return self.guides and next(self.guides) ~= nil and compatible
-end
+function addon.talents:IsSupported() return self.guides and next(self.guides) ~= nil and compatible end
 
 function addon.talents:Setup()
     if not addon.settings.profile.enableTalentGuides then return end
@@ -184,8 +162,7 @@ function addon.talents:Setup()
 
     self:UpdateSelectedGuide(RXPCData.activeTalentGuide)
 
-    if tonumber(GetCVar("previewTalents")) == 0 and addon.gameVersion > 30000 and
-        addon.settings.profile.previewTalents then
+    if tonumber(GetCVar("previewTalents")) == 0 and addon.gameVersion > 30000 and addon.settings.profile.previewTalents then
         -- Talents are enabled in RXP, so match client
         -- This only lasts per session, does not persist in-game setting
         SetCVar("previewTalents", 1)
@@ -195,19 +172,16 @@ end
 function addon.talents:ADDON_LOADED(_, loadedAddon)
     -- Talent frame/globals get loaded on demand when it's first opened
     if loadedAddon == "Blizzard_TalentUI" then
-        _G.PlayerTalentFrame:HookScript("OnShow",
-                                        function() addon.talents:HookUI() end)
+        _G.PlayerTalentFrame:HookScript("OnShow", function() addon.talents:HookUI() end)
 
-        _G.PlayerTalentFrame:HookScript("OnUpdate",
-                                        function() self:DrawTalents() end)
+        _G.PlayerTalentFrame:HookScript("OnUpdate", function() self:DrawTalents() end)
 
         PlayerTalentFrame = _G.PlayerTalentFrame
 
         self:BuildIndexLookup()
     elseif loadedAddon == "Talented" then
         compatible = false
-        addon.comms.PrettyPrint(L(
-                                    "Talented detected, please disable for talent guide functionality")) -- TODO locale
+        addon.comms.PrettyPrint(L("Talented detected, please disable for talent guide functionality")) -- TODO locale
     end
 end
 
@@ -220,9 +194,7 @@ function addon.talents:UpdateTalentsButton()
 
         -- Offset RXP button as much as Tab2 is from Tab1
         _, _, _, _, iconReference.offsetY = _G.PlayerSpecTab3:GetPoint()
-        iconReference.point = {
-            "TOP", iconReference.frame, "BOTTOM", 0, iconReference.offsetY
-        }
+        iconReference.point = {"TOP", iconReference.frame, "BOTTOM", 0, iconReference.offsetY}
 
     elseif _G.PlayerSpecTab2 and _G.PlayerSpecTab2:IsShown() then -- Dual spec non-hunter
         iconReference.frame = _G.PlayerSpecTab2
@@ -231,27 +203,19 @@ function addon.talents:UpdateTalentsButton()
         -- Offset RXP button as much as Tab2 is from Tab1
         _, _, _, _, iconReference.offsetY = _G.PlayerSpecTab2:GetPoint()
 
-        iconReference.point = {
-            "TOP", iconReference.frame, "BOTTOM", 0, iconReference.offsetY
-        }
+        iconReference.point = {"TOP", iconReference.frame, "BOTTOM", 0, iconReference.offsetY}
     elseif addon.game == "CATA" and _G.PlayerSpecTab1 then -- Cata, non dual-spec non-hunter
         iconReference.frame = _G.PlayerTalentFrame
         iconReference.size = 32
-        iconReference.point = {
-            "TOPLEFT", iconReference.frame, "TOPRIGHT", 0, -65
-        }
+        iconReference.point = {"TOPLEFT", iconReference.frame, "TOPRIGHT", 0, -65}
     elseif _G.PlayerSpecTab1 then -- Wrath, non dual-spec non-hunter
         iconReference.frame = _G.PlayerTalentFrame
         iconReference.size = 32
-        iconReference.point = {
-            "TOPLEFT", iconReference.frame, "TOPRIGHT", -32, -65
-        }
+        iconReference.point = {"TOPLEFT", iconReference.frame, "TOPRIGHT", -32, -65}
     elseif addon.gameVersion < 20000 then
         iconReference.frame = _G.PlayerTalentFrame
         iconReference.size = 32
-        iconReference.point = {
-            "TOPLEFT", iconReference.frame, "TOPRIGHT", -32, -65
-        }
+        iconReference.point = {"TOPLEFT", iconReference.frame, "TOPRIGHT", -32, -65}
         -- elseif Retail
     else
         return nil
@@ -276,9 +240,7 @@ function addon.talents:UpdateTalentsButton()
         self.talentsButton = button
 
         button:SetScript("OnEnter", function(this)
-            if this:IsForbidden() or GameTooltip:IsForbidden() then
-                return
-            end
+            if this:IsForbidden() or GameTooltip:IsForbidden() then return end
             GameTooltip:SetOwner(this, "ANCHOR_TOPLEFT", iconReference.size, 0)
             GameTooltip:ClearLines()
 
@@ -286,20 +248,16 @@ function addon.talents:UpdateTalentsButton()
             if guide then
                 GameTooltip:AddLine(guide.name)
                 GameTooltip:AddLine(L("Left click to apply talents"), 0, 1, 0)
-                GameTooltip:AddLine(fmt("%s: %d - %d", _G.LEVEL_RANGE,
-                                        guide.minLevel, guide.maxLevel), 1, 1, 1)
+                GameTooltip:AddLine(fmt("%s: %d - %d", _G.LEVEL_RANGE, guide.minLevel, guide.maxLevel), 1, 1, 1)
             else
-                GameTooltip:AddLine(L(
-                                        "Welcome to RestedXP Guides\nRight click to pick a guide"))
+                GameTooltip:AddLine(L("Welcome to RestedXP Guides\nRight click to pick a guide"))
             end
 
             GameTooltip:Show()
         end)
 
         button:SetScript("OnLeave", function(this)
-            if this:IsForbidden() or GameTooltip:IsForbidden() then
-                return
-            end
+            if this:IsForbidden() or GameTooltip:IsForbidden() then return end
             GameTooltip:Hide()
         end)
 
@@ -323,21 +281,17 @@ function addon.talents:HookUI()
     end
 
     if not talentTooltips.hooked then
-        hooksecurefunc("PlayerTalentFrameTalent_OnEnter",
-                       talentTooltips.updateFunc)
+        hooksecurefunc("PlayerTalentFrameTalent_OnEnter", talentTooltips.updateFunc)
 
         talentTooltips.hooked = true
     end
 
     if not self.menuFrame then
-        self.menuFrame = CreateFrame("Frame", "RXP_TalentsMenuFrame",
-                                     self.talentsButton,
-                                     "UIDropDownMenuTemplate")
+        self.menuFrame = CreateFrame("Frame", "RXP_TalentsMenuFrame", self.talentsButton, "UIDropDownMenuTemplate")
 
         self.talentsButton:SetScript("OnMouseUp", function(_, click)
             if click == "RightButton" then
-                EasyMenu(buildTalentGuidesMenu(), self.menuFrame,
-                         self.talentsButton, 0, 0, "MENU", 1)
+                EasyMenu(buildTalentGuidesMenu(), self.menuFrame, self.talentsButton, 0, 0, "MENU", 1)
             else
                 self:ProcessTalents()
             end
@@ -383,8 +337,7 @@ function addon.talents:ParseGuide(text)
         elseif currentStep > 0 then -- Parse metadata tags first
 
             -- Parse function calls
-            parseSuccess = line:gsub("^%.(%S+)%s*(.*)",
-                                     function(command, lineArgs)
+            parseSuccess = line:gsub("^%.(%S+)%s*(.*)", function(command, lineArgs)
                 -- print("Processing guide command", command, "with (", lineArgs, ")")
                 if self.functions[command] then
                     local element = self.functions[command](lineArgs)
@@ -397,10 +350,8 @@ function addon.talents:ParseGuide(text)
 
                     tinsert(step.elements, element)
                 else
-                    addon.error(L("Error parsing guide") .. " " ..
-                                    (guide.name or 'Unknown') ..
-                                    ": Invalid function call (." .. command ..
-                                    ")\n" .. line)
+                    addon.error(L("Error parsing guide") .. " " .. (guide.name or 'Unknown') ..
+                                    ": Invalid function call (." .. command .. ")\n" .. line)
                 end
             end)
 
@@ -409,16 +360,13 @@ function addon.talents:ParseGuide(text)
             parseSuccess = line:gsub("^#(%S+)%s*(.*)", function(tag, value)
                 -- print("Parsing tag at", linenumber, tag, value)
                 -- Set metadata without overwriting
-                if tag and tag ~= "" and not guide[tag] then
-                    guide[tag] = value
-                end
+                if tag and tag ~= "" and not guide[tag] then guide[tag] = value end
             end)
 
         end
 
         if not parseSuccess or internalParseFailure then
-            addon.comms.PrettyPrint("%s: Critical failure for $s",
-                                    L("Error parsing guide"),
+            addon.comms.PrettyPrint("%s: Critical failure for $s", L("Error parsing guide"),
                                     guide.name or guide.key or 'Unknown')
 
             return
@@ -427,21 +375,17 @@ function addon.talents:ParseGuide(text)
 
     -- Ensure guide tags exist with good defaults
     if not guide.name then
-        addon.comms.PrettyPrint("%s: Missing #%s", L("Error parsing guide"),
-                                "name")
+        addon.comms.PrettyPrint("%s: Missing #%s", L("Error parsing guide"), "name")
         return
     end
 
     guide.minLevel = tonumber(guide.minLevel) or 10
     guide.maxLevel = tonumber(guide.maxLevel) or addon.talents.maxLevel
     guide.levelRange = fmt("%d-%d", guide.minLevel, guide.maxLevel)
-    guide.description = guide.description or
-                            fmt("%s - %s (%s)", addon.player.localeClass,
-                                guide.name, guide.levelRange)
+    guide.description = guide.description or fmt("%s - %s (%s)", addon.player.localeClass, guide.name, guide.levelRange)
     guide.displayname = guide.displayname or guide.description
     guide.key = guide.key or fmt("%s - %s", addon.player.class, guide.name)
-    guide.nextKey = guide.next and
-                        fmt("%s - %s", addon.player.class, guide.next)
+    guide.nextKey = guide.next and fmt("%s - %s", addon.player.class, guide.next)
 
     return guide
 end
@@ -471,12 +415,8 @@ function addon.talents.functions.talent(element, validate)
 
         local tab, tier, column, rank = strsplit(',', args)
         -- print("Inserting talent", arg)
-        tinsert(e.talent, {
-            tab = tonumber(tab),
-            tier = tonumber(tier),
-            column = tonumber(column),
-            rank = tonumber(rank) or 1
-        })
+        tinsert(e.talent,
+                {tab = tonumber(tab), tier = tonumber(tier), column = tonumber(column), rank = tonumber(rank) or 1})
 
         return e
     end
@@ -489,12 +429,10 @@ function addon.talents.functions.talent(element, validate)
     for _, talentData in ipairs(element.talent) do
         lookup = indexLookup['player'][talentData.tab]
 
-        if not (lookup and lookup[talentData.tier] and
-            lookup[talentData.tier][talentData.column]) then
+        if not (lookup and lookup[talentData.tier] and lookup[talentData.tier][talentData.column]) then
 
-            addon.comms.PrettyPrint(
-                "Invalid talentIndex lookup for [%d][%d][%d]", talentData.tab,
-                talentData.tier, talentData.column)
+            addon.comms.PrettyPrint("Invalid talentIndex lookup for [%d][%d][%d]", talentData.tab, talentData.tier,
+                                    talentData.column)
             return false
         end
 
@@ -506,16 +444,11 @@ function addon.talents.functions.talent(element, validate)
 
         if addon.gameVersion > 40000 then
             -- Return values don't match API docs/TWW, so used /dump GetTalentInfo(1,11) for Arms War
-            name, _, _, _, _, _, _, previewRankOrRank = GetTalentInfo(
-                                                            talentData.tab,
-                                                            talentIndex)
+            name, _, _, _, _, _, _, previewRankOrRank = GetTalentInfo(talentData.tab, talentIndex)
         elseif addon.gameVersion > 30000 then
-            name, _, _, _, _, _, _, _, previewRankOrRank, _ = GetTalentInfo(
-                                                                  talentData.tab,
-                                                                  talentIndex)
+            name, _, _, _, _, _, _, _, previewRankOrRank, _ = GetTalentInfo(talentData.tab, talentIndex)
         else
-            name, _, _, _, previewRankOrRank =
-                GetTalentInfo(talentData.tab, talentIndex)
+            name, _, _, _, previewRankOrRank = GetTalentInfo(talentData.tab, talentIndex)
         end
 
         if previewRankOrRank < talentData.rank then
@@ -523,8 +456,7 @@ function addon.talents.functions.talent(element, validate)
                 local d = {talentData.tab, talentIndex, name}
                 local prompt = fmt(_G.CONFIRM_LEARN_TALENT, name)
 
-                addon.comms:ConfirmChoice("RXPTalentPrompt", prompt,
-                                          learnClassicTalent, d)
+                addon.comms:ConfirmChoice("RXPTalentPrompt", prompt, learnClassicTalent, d)
 
                 -- Stop as soon as first learning prompt, not a blocking dialog
                 return -1
@@ -534,21 +466,17 @@ function addon.talents.functions.talent(element, validate)
 
                 -- Verify training actually worked, there's no return value from Preview
                 if before == GetGroupPreviewTalentPointsSpent() then
-                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN,
-                                    name))
+                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN, name))
                     return false
                 end
 
-                addon.comms.PrettyPrint("%s - %s (%s %d)", _G.PREVIEW, name,
-                                        _G.RANK, talentData.rank)
+                addon.comms.PrettyPrint("%s - %s (%s %d)", _G.PREVIEW, name, _G.RANK, talentData.rank)
             else
                 if LearnTalent(talentData.tab, talentIndex) then
-                    addon.comms.PrettyPrint("%s - %s (%s %d)",
-                                            _G.TRADE_SKILLS_LEARNED_TAB, name,
-                                            _G.RANK, talentData.rank)
+                    addon.comms.PrettyPrint("%s - %s (%s %d)", _G.TRADE_SKILLS_LEARNED_TAB, name, _G.RANK,
+                                            talentData.rank)
                 else
-                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN,
-                                    name))
+                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN, name))
                     return false
                 end
             end
@@ -571,12 +499,8 @@ function addon.talents.functions.pettalent(element, validate)
         local tab, tier, column, rank = strsplit(',', args)
 
         -- print("Inserting pettalent", arg)
-        tinsert(e.pettalent, {
-            tab = tonumber(tab),
-            tier = tonumber(tier),
-            column = tonumber(column),
-            rank = tonumber(rank) or 1
-        })
+        tinsert(e.pettalent,
+                {tab = tonumber(tab), tier = tonumber(tier), column = tonumber(column), rank = tonumber(rank) or 1})
 
         return e
     end
@@ -588,12 +512,10 @@ function addon.talents.functions.pettalent(element, validate)
     for _, talentData in pairs(element.pettalent) do
         lookup = indexLookup[GetPetTalentTree()][talentData.tab]
 
-        if not (lookup and lookup[talentData.tier] and
-            lookup[talentData.tier][talentData.column]) then
+        if not (lookup and lookup[talentData.tier] and lookup[talentData.tier][talentData.column]) then
 
-            addon.comms.PrettyPrint(
-                "Invalid pet talentIndex lookup for [%d][%d][%d]",
-                talentData.tab, talentData.tier, talentData.column)
+            addon.comms.PrettyPrint("Invalid pet talentIndex lookup for [%d][%d][%d]", talentData.tab, talentData.tier,
+                                    talentData.column)
             return false
         end
 
@@ -601,35 +523,27 @@ function addon.talents.functions.pettalent(element, validate)
 
         if talentIndex and validate then return true end
 
-        name, _, _, _, _, _, _, _, previewRankOrRank, _ = GetTalentInfo(
-                                                              talentData.tab,
-                                                              talentIndex, nil,
-                                                              true)
+        name, _, _, _, _, _, _, _, previewRankOrRank, _ = GetTalentInfo(talentData.tab, talentIndex, nil, true)
 
         -- TODO handle off-plan talents
         if name and previewRankOrRank < talentData.rank then
             if addon.settings.profile.previewTalents then
                 local before = GetGroupPreviewTalentPointsSpent(true, 1)
-                AddPreviewTalentPoints(talentData.tab, talentIndex, 1, true,
-                                       PlayerTalentFrame.talentGroup)
+                AddPreviewTalentPoints(talentData.tab, talentIndex, 1, true, PlayerTalentFrame.talentGroup)
 
                 -- Verify training actually worked, there's no return value from Preview
                 if before == GetGroupPreviewTalentPointsSpent(true, 1) then
-                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN,
-                                    name))
+                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN, name))
                     return false
                 end
 
-                addon.comms.PrettyPrint("%s - %s (%s %d)", _G.PREVIEW, name,
-                                        _G.RANK, talentData.rank)
+                addon.comms.PrettyPrint("%s - %s (%s %d)", _G.PREVIEW, name, _G.RANK, talentData.rank)
             else
                 if LearnTalent(talentData.tab, talentIndex, true) then
-                    addon.comms.PrettyPrint("%s - %s (%s %d)",
-                                            _G.TRADE_SKILLS_LEARNED_TAB, name,
-                                            _G.RANK, talentData.rank)
+                    addon.comms.PrettyPrint("%s - %s (%s %d)", _G.TRADE_SKILLS_LEARNED_TAB, name, _G.RANK,
+                                            talentData.rank)
                 else
-                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN,
-                                    name))
+                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN, name))
                     return false
                 end
             end
@@ -655,8 +569,7 @@ function addon.talents:UpdateSelectedGuide(key)
     if not self.guides[key] then return end
 
     if UnitLevel("player") < self.guides[key].minLevel then
-        addon.comms.PrettyPrint(L("Too low for %s"),
-                                self.guides[key].displayname)
+        addon.comms.PrettyPrint(L("Too low for %s"), self.guides[key].displayname)
 
         return
     end
@@ -683,27 +596,19 @@ if addon.gameVersion < 40000 then
     end
 else
     talentTooltips.updateFunc = function(talentIndexFrame)
-        if not (talentIndexFrame.RXP and talentIndexFrame.RXP.levels) then
-            return
-        end
+        if not (talentIndexFrame.RXP and talentIndexFrame.RXP.levels) then return end
 
         -- Because drawing at tooltip time, extra step required to order it vs everytime in drawTalents
         local sorted_levels = {}
-        for l, _ in pairs(talentIndexFrame.RXP.levels) do
-            tinsert(sorted_levels, l)
-        end
+        for l, _ in pairs(talentIndexFrame.RXP.levels) do tinsert(sorted_levels, l) end
 
         tsort(sorted_levels)
 
         local levelsCsv = ''
-        for _, level in pairs(sorted_levels) do
-            levelsCsv = fmt('%s%d ', levelsCsv, level)
-        end
+        for _, level in pairs(sorted_levels) do levelsCsv = fmt('%s%d ', levelsCsv, level) end
 
         -- Only calculate string on tooltip hover, vs every DrawTalents like on Era
-        local rxpTooltip = fmt("%s\n%s%s: %s %s|r",
-                               talentIndexFrame.RXP.tooltipTextHeader,
-                               addon.colors.tooltip,
+        local rxpTooltip = fmt("%s\n%s%s: %s %s|r", talentIndexFrame.RXP.tooltipTextHeader, addon.colors.tooltip,
                                _G.TRADE_SKILLS_LEARNED_TAB, _G.LEVEL, levelsCsv)
         -- Handle refreshing of UI
         GameTooltip:AddLine(rxpTooltip, 1, 1, 1)
@@ -719,8 +624,7 @@ local function DrawTalentLevels(talentIndex, numbers)
     if not ht then return end
 
     if not ht.levelHeader then
-        ht.levelHeader = CreateFrame("Frame", "$parent_levelText",
-                                     _G["PlayerTalentFrameTalent" .. talentIndex],
+        ht.levelHeader = CreateFrame("Frame", "$parent_levelText", _G["PlayerTalentFrameTalent" .. talentIndex],
                                      BackdropTemplate)
 
         ht.levelHeader:SetPoint("TOPLEFT", ht, 0, 0)
@@ -794,15 +698,13 @@ function addon.talents:DrawTalents()
     local remainingPoints, levelStep, talentIndex
 
     if GetUnspentTalentPoints then
-        remainingPoints = GetUnspentTalentPoints() -
-                              GetGroupPreviewTalentPointsSpent()
+        remainingPoints = GetUnspentTalentPoints() - GetGroupPreviewTalentPointsSpent()
     else
         remainingPoints = UnitCharacterPoints("player")
     end
 
     local playerLevel = UnitLevel("player")
-    local advancedWarning = playerLevel +
-                                addon.settings.profile.upcomingTalentCount
+    local advancedWarning = playerLevel + addon.settings.profile.upcomingTalentCount
     wipe(talentTooltips.data)
 
     -- Track state better than with Blizz frame re-use
@@ -819,44 +721,32 @@ function addon.talents:DrawTalents()
             for _, element in ipairs(levelStep.elements) do
                 for _, talentData in ipairs(element.talent) do
 
-                    talentIndex =
-                        indexLookup['player'][talentData.tab][talentData.tier][talentData.column]
+                    talentIndex = indexLookup['player'][talentData.tab][talentData.tier][talentData.column]
 
                     if currentTab == talentData.tab then
                         activeIndices[talentIndex] = talentData.tab
 
-                        talentTooltips.data[talentIndex] =
-                            talentTooltips.data[talentIndex] or
-                                fmt("\n%s - %s", addon.title, guide.name)
+                        talentTooltips.data[talentIndex] = talentTooltips.data[talentIndex] or
+                                                               fmt("\n%s - %s", addon.title, guide.name)
 
-                        talentTooltips.data[talentIndex] = fmt(
-                                                               "%s\n%s%s: %s %d|r",
-                                                               talentTooltips.data[talentIndex],
-                                                               addon.colors
-                                                                   .tooltip,
-                                                               _G.TRADE_SKILLS_LEARNED_TAB,
-                                                               _G.LEVEL,
-                                                               upcomingTalent)
+                        talentTooltips.data[talentIndex] = fmt("%s\n%s%s: %s %d|r", talentTooltips.data[talentIndex],
+                                                               addon.colors.tooltip, _G.TRADE_SKILLS_LEARNED_TAB,
+                                                               _G.LEVEL, upcomingTalent)
 
                         -- TODO Pre-seed tooltip to prevent delay
 
                         if not talentTooltips.highlights[talentIndex] then
-                            local ht = _G["PlayerTalentFrameTalent" ..
-                                           talentIndex]:CreateTexture(
+                            local ht = _G["PlayerTalentFrameTalent" .. talentIndex]:CreateTexture(
                                            "$parent_LevelPreview", "BORDER")
 
-                            ht:SetTexture(
-                                "Interface/Buttons/ButtonHilight-Square")
+                            ht:SetTexture("Interface/Buttons/ButtonHilight-Square")
                             ht:SetBlendMode("ADD")
-                            ht:SetAllPoints(
-                                _G["PlayerTalentFrameTalent" .. talentIndex ..
-                                    "Slot"])
+                            ht:SetAllPoints(_G["PlayerTalentFrameTalent" .. talentIndex .. "Slot"])
 
                             talentTooltips.highlights[talentIndex] = ht
                         end
 
-                        setHighlightColor(talentIndex,
-                                          upcomingTalent - playerLevel)
+                        setHighlightColor(talentIndex, upcomingTalent - playerLevel)
 
                         if levelsForIndex[talentIndex] then
                             tinsert(levelsForIndex[talentIndex], upcomingTalent)
@@ -880,9 +770,7 @@ function addon.talents:DrawTalents()
             DrawTalentLevels(index, levelsForIndex[index])
 
             if not ht:IsShown() then ht:Show() end
-            if not ht.levelHeader:IsShown() then
-                ht.levelHeader:Show()
-            end
+            if not ht.levelHeader:IsShown() then ht.levelHeader:Show() end
         else
             if ht:IsShown() then ht:Hide() end
             if ht.levelHeader:IsShown() then ht.levelHeader:Hide() end
@@ -904,28 +792,21 @@ function addon.talents:BuildIndexLookup()
 
     -- print("BuildIndexLookup() looping", kind)
 
-    for tabIndex = 1, _G.GetNumTalentTabs(nil, PlayerTalentFrame.pet,
-                                          PlayerTalentFrame.talentGroup) do
+    for tabIndex = 1, _G.GetNumTalentTabs(nil, PlayerTalentFrame.pet, PlayerTalentFrame.talentGroup) do
         indexLookup[kind][tabIndex] = {}
 
-        for talentIndex = 1, _G.GetNumTalents(tabIndex, nil,
-                                              PlayerTalentFrame.pet,
-                                              PlayerTalentFrame.talentGroup) do
-            name, _, tier, column = GetTalentInfo(tabIndex, talentIndex, nil,
-                                                  PlayerTalentFrame.pet,
+        for talentIndex = 1, _G.GetNumTalents(tabIndex, nil, PlayerTalentFrame.pet, PlayerTalentFrame.talentGroup) do
+            name, _, tier, column = GetTalentInfo(tabIndex, talentIndex, nil, PlayerTalentFrame.pet,
                                                   PlayerTalentFrame.talentGroup)
             if name then
-                indexLookup[kind][tabIndex][tier] =
-                    indexLookup[kind][tabIndex][tier] or {}
+                indexLookup[kind][tabIndex][tier] = indexLookup[kind][tabIndex][tier] or {}
                 indexLookup[kind][tabIndex][tier][column] = talentIndex
             end
 
         end
     end
 
-    if indexLookup[kind][1] and indexLookup[kind][1][1] then
-        indexLookup[kind].initialized = true
-    end
+    if indexLookup[kind][1] and indexLookup[kind][1][1] then indexLookup[kind].initialized = true end
 end
 
 function addon.talents:ProcessTalents(validate)
@@ -939,9 +820,7 @@ function addon.talents:ProcessTalents(validate)
 
     if not guide then return end
 
-    if validate and addon.settings.profile.debug then
-        addon.comms.PrettyPrint("Validating %s", guide.displayname)
-    end
+    if validate and addon.settings.profile.debug then addon.comms.PrettyPrint("Validating %s", guide.displayname) end
 
     if playerLevel < guide.minLevel and not validate then
         addon.comms.PrettyPrint(L("Too low for %s"), guide.displayname) --
@@ -954,8 +833,7 @@ function addon.talents:ProcessTalents(validate)
     end
 
     if addon.game == "CATA" then
-        if _G.PanelTemplates_GetSelectedTab(PlayerTalentFrame) ==
-            _G.GLYPH_TALENT_TAB then
+        if _G.PanelTemplates_GetSelectedTab(PlayerTalentFrame) == _G.GLYPH_TALENT_TAB then
             _G["PlayerTalentFrameTab" .. _G.TALENTS_TAB]:Click()
         end
         -- Cata uses gives summary of trees on fresh 10/respec "View Talent Trees"
@@ -971,20 +849,16 @@ function addon.talents:ProcessTalents(validate)
             if firstTalentTab > -1 then break end
 
             for _, element in ipairs(step.elements) do
-                if element.talent and element.talent[1] and
-                    element.talent[1].tab then
+                if element.talent and element.talent[1] and element.talent[1].tab then
                     firstTalentTab = element.talent[1].tab
                     break
                 end
             end
         end
 
-        local firstTalentTabButton = _G["PlayerTalentFramePanel" ..
-                                         firstTalentTab .. "SelectTreeButton"]
+        local firstTalentTabButton = _G["PlayerTalentFramePanel" .. firstTalentTab .. "SelectTreeButton"]
         if firstTalentTabButton then
-            if firstTalentTabButton:IsShown() then
-                firstTalentTabButton:Click()
-            end
+            if firstTalentTabButton:IsShown() then firstTalentTabButton:Click() end
         else
             -- Failure to get first tab, panic?
         end
@@ -996,8 +870,7 @@ function addon.talents:ProcessTalents(validate)
         stepLevel = guide.minLevel + stepNum - 1
 
         if GetUnspentTalentPoints then
-            remainingPoints = GetUnspentTalentPoints() -
-                                  GetGroupPreviewTalentPointsSpent()
+            remainingPoints = GetUnspentTalentPoints() - GetGroupPreviewTalentPointsSpent()
         else
             remainingPoints = UnitCharacterPoints("player")
         end
@@ -1007,8 +880,7 @@ function addon.talents:ProcessTalents(validate)
                 addon.comms.PrettyPrint(L("Reached maximum level for guide"))
 
                 if self:UpdateSelectedGuide(guide.nextKey) then
-                    addon.comms.PrettyPrint(L("Loaded next guide, %s"),
-                                            guide.next)
+                    addon.comms.PrettyPrint(L("Loaded next guide, %s"), guide.next)
                 end
             end
 
@@ -1026,10 +898,8 @@ function addon.talents:ProcessTalents(validate)
                     result = self.functions[tag](element, validate)
                 else
                     result = false
-                    addon.error(L("Error parsing guide") .. " " ..
-                                    (guide.name or 'Unknown') ..
-                                    ": Invalid function call (." .. tag .. ")\n" ..
-                                    stepNum)
+                    addon.error(L("Error parsing guide") .. " " .. (guide.name or 'Unknown') ..
+                                    ": Invalid function call (." .. tag .. ")\n" .. stepNum)
                 end
 
                 -- Exit processing if error found
@@ -1057,9 +927,7 @@ function addon.talents:ProcessPetTalents(validate)
 
     if not guide or not guide.pet then return end
 
-    if validate and addon.settings.profile.debug then
-        addon.comms.PrettyPrint("Validating %s", guide.displayname)
-    end
+    if validate and addon.settings.profile.debug then addon.comms.PrettyPrint("Validating %s", guide.displayname) end
 
     if playerLevel < guide.minLevel and not validate then
         addon.comms.PrettyPrint(L("Too low for %s"), guide.displayname) --
@@ -1074,8 +942,7 @@ function addon.talents:ProcessPetTalents(validate)
     local remainingPoints
 
     for stepNum, step in ipairs(guide.steps) do
-        remainingPoints = GetUnspentTalentPoints(nil, true) -
-                              GetGroupPreviewTalentPointsSpent(true, 1)
+        remainingPoints = GetUnspentTalentPoints(nil, true) - GetGroupPreviewTalentPointsSpent(true, 1)
 
         if remainingPoints == 0 then
             if not validate and playerLevel == guide.maxLevel then
@@ -1096,16 +963,13 @@ function addon.talents:ProcessPetTalents(validate)
                     result = self.functions[tag](element, validate)
                 else
                     result = false
-                    addon.error(L("Error parsing guide") .. " " ..
-                                    (guide.name or 'Unknown') ..
-                                    ": Invalid function call (." .. tag .. ")\n" ..
-                                    stepNum)
+                    addon.error(L("Error parsing guide") .. " " .. (guide.name or 'Unknown') ..
+                                    ": Invalid function call (." .. tag .. ")\n" .. stepNum)
                 end
 
                 if result == false then
                     if addon.settings.profile.debug then
-                        addon.comms.PrettyPrint(
-                            "Aborting processing at step %d", stepNum)
+                        addon.comms.PrettyPrint("Aborting processing at step %d", stepNum)
                     end
                     return
                 end
@@ -1125,25 +989,18 @@ local function cataDrawTalentLevels(talentIndexFrameName, levels)
 
     if not talentIndexFrame.levelHeader then
         local anchor = _G[talentIndexFrameName .. 'IconOverlay']
-        talentIndexFrame.levelHeader = CreateFrame("Frame",
-                                                   "$parent_RXPLevelText",
-                                                   anchor or talentIndexFrame,
+        talentIndexFrame.levelHeader = CreateFrame("Frame", "$parent_RXPLevelText", anchor or talentIndexFrame,
                                                    BackdropTemplate)
 
-        talentIndexFrame.levelHeader:SetPoint("BOTTOMLEFT", talentIndexFrame,
-                                              "TOPLEFT", 0, -4)
-        talentIndexFrame.levelHeader.text =
-            talentIndexFrame.levelHeader:CreateFontString(nil, "OVERLAY")
+        talentIndexFrame.levelHeader:SetPoint("BOTTOMLEFT", talentIndexFrame, "TOPLEFT", 0, -4)
+        talentIndexFrame.levelHeader.text = talentIndexFrame.levelHeader:CreateFontString(nil, "OVERLAY")
 
         talentIndexFrame.levelHeader.text:ClearAllPoints()
-        talentIndexFrame.levelHeader.text:SetPoint("LEFT",
-                                                   talentIndexFrame.levelHeader,
-                                                   0, 0)
+        talentIndexFrame.levelHeader.text:SetPoint("LEFT", talentIndexFrame.levelHeader, 0, 0)
         talentIndexFrame.levelHeader.text:SetJustifyH("LEFT")
         talentIndexFrame.levelHeader.text:SetJustifyV("MIDDLE")
 
-        talentIndexFrame.levelHeader.text:SetTextColor(
-            unpack(addon.activeTheme.textColor))
+        talentIndexFrame.levelHeader.text:SetTextColor(unpack(addon.activeTheme.textColor))
         talentIndexFrame.levelHeader.text:SetFont(addon.font, 8, "OUTLINE")
     end
 
@@ -1158,32 +1015,26 @@ local function cataDrawTalentLevels(talentIndexFrameName, levels)
     -- If 5 levels of preview, overlaps with nearby
     if #sorted_levels < 4 then
         -- talentIndexFrame.levelHeader.text:SetFont(addon.font, 8, "OUTLINE")
-        talentIndexFrame.levelHeader:SetPoint("BOTTOMLEFT", talentIndexFrame,
-                                              "TOPLEFT", 0, -4)
+        talentIndexFrame.levelHeader:SetPoint("BOTTOMLEFT", talentIndexFrame, "TOPLEFT", 0, -4)
     else
         -- talentIndexFrame.levelHeader.text:SetFont(addon.font, 8, "OUTLINE")
-        talentIndexFrame.levelHeader:SetPoint("BOTTOMLEFT", talentIndexFrame,
-                                              "TOPLEFT", -2 * #sorted_levels, -4)
+        talentIndexFrame.levelHeader:SetPoint("BOTTOMLEFT", talentIndexFrame, "TOPLEFT", -2 * #sorted_levels, -4)
     end
 
     -- No changes, prevent uneeded UI calls
     if talentIndexFrame.levelHeader.text:GetText() == newText then return end
 
     talentIndexFrame.levelHeader.text:SetText(newText)
-    talentIndexFrame.levelHeader:SetSize(
-        talentIndexFrame.levelHeader.text:GetStringWidth() + 10, 17)
+    talentIndexFrame.levelHeader:SetSize(talentIndexFrame.levelHeader.text:GetStringWidth() + 10, 17)
 end
 
 -- https://www.wowhead.com/guide=cataclysm&mastery#talents
 local cataTalentLevels = {
-    10, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45,
-    47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 82,
-    83, 84, 85
+    10, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65,
+    67, 69, 71, 73, 75, 77, 79, 81, 82, 83, 84, 85
 }
 
-local function lookupTalentLevel(nextTalentStepIndex)
-    return cataTalentLevels[nextTalentStepIndex]
-end
+local function lookupTalentLevel(nextTalentStepIndex) return cataTalentLevels[nextTalentStepIndex] end
 
 function addon.talents.cata:DrawTalents(guide)
     guide = guide or self:GetCurrentGuide()
@@ -1207,16 +1058,14 @@ function addon.talents.cata:DrawTalents(guide)
     local remainingPoints, levelStep, talentIndex
 
     if GetUnspentTalentPoints then
-        remainingPoints = GetUnspentTalentPoints() -
-                              GetGroupPreviewTalentPointsSpent()
+        remainingPoints = GetUnspentTalentPoints() - GetGroupPreviewTalentPointsSpent()
     else
         remainingPoints = UnitCharacterPoints("player")
     end
 
     local playerLevel = UnitLevel("player")
 
-    local advancedWarning = playerLevel +
-                                addon.settings.profile.upcomingTalentCount
+    local advancedWarning = playerLevel + addon.settings.profile.upcomingTalentCount
 
     -- TODO cache data if unchanged
     local talentInfo, levelLookup, levelStepIndex
@@ -1231,22 +1080,18 @@ function addon.talents.cata:DrawTalents(guide)
             for _, element in ipairs(levelStep.elements) do
                 for _, talentData in ipairs(element.talent) do
 
-                    talentIndex =
-                        indexLookup['player'][talentData.tab][talentData.tier][talentData.column]
+                    talentIndex = indexLookup['player'][talentData.tab][talentData.tier][talentData.column]
 
                     if talentTooltips.cataPlan[talentData.tab][talentIndex] then
-                        talentInfo =
-                            talentTooltips.cataPlan[talentData.tab][talentIndex]
+                        talentInfo = talentTooltips.cataPlan[talentData.tab][talentIndex]
                     else
                         talentInfo = {
                             levels = {},
                             talentData = talentData,
-                            tooltipTextHeader = fmt("%s - %s", addon.title,
-                                                    guide.name)
+                            tooltipTextHeader = fmt("%s - %s", addon.title, guide.name)
                         }
 
-                        talentTooltips.cataPlan[talentData.tab][talentIndex] =
-                            talentInfo
+                        talentTooltips.cataPlan[talentData.tab][talentIndex] = talentInfo
                     end
 
                     levelLookup = lookupTalentLevel(levelStepIndex)
@@ -1260,11 +1105,9 @@ function addon.talents.cata:DrawTalents(guide)
                     end
 
                     if not talentInfo.talentIndexFrameName then
-                        talentInfo.talentIndexFrameName =
-                            "PlayerTalentFramePanel" .. talentData.tab ..
-                                "Talent" .. talentIndex
-                        talentInfo.talentIndexFrame =
-                            _G[talentInfo.talentIndexFrameName]
+                        talentInfo.talentIndexFrameName = "PlayerTalentFramePanel" .. talentData.tab .. "Talent" ..
+                                                              talentIndex
+                        talentInfo.talentIndexFrame = _G[talentInfo.talentIndexFrameName]
 
                         -- Add reverse lookup for tooltip updateFunc logic
                         talentInfo.talentIndexFrame.RXP = talentInfo
@@ -1289,9 +1132,7 @@ function addon.talents.cata:DrawTalents(guide)
 end
 
 function addon.talents.cata.CleanupTalentPlan()
-    if _G.PlayerTalentFrameResetButton_OnClick then
-        _G.PlayerTalentFrameResetButton_OnClick()
-    end
+    if _G.PlayerTalentFrameResetButton_OnClick then _G.PlayerTalentFrameResetButton_OnClick() end
 
     local f
 
@@ -1302,9 +1143,7 @@ function addon.talents.cata.CleanupTalentPlan()
             if f and f.levelHeader and f.levelHeader:IsShown() then
                 f.levelHeader:Hide()
 
-                if f.levelHeader.text then
-                    f.levelHeader.text:SetText(nil)
-                end
+                if f.levelHeader.text then f.levelHeader.text:SetText(nil) end
             end
 
             wipe(tInfo.levels)

--- a/Talents.lua
+++ b/Talents.lua
@@ -184,7 +184,7 @@ function addon.talents:Setup()
 
     self:UpdateSelectedGuide(RXPCData.activeTalentGuide)
 
-    if tonumber(GetCVar("previewTalents")) == 0 and addon.gameVersion > 30000 and
+    if tonumber(GetCVar("previewTalents")) == 0 and addon.game == "WOTLK" and
         addon.settings.profile.previewTalents then
         -- Talents are enabled in RXP, so match client
         -- This only lasts per session, does not persist in-game setting
@@ -246,7 +246,7 @@ function addon.talents:UpdateTalentsButton()
         iconReference.point = {
             "TOPLEFT", iconReference.frame, "TOPRIGHT", -32, -65
         }
-    elseif addon.gameVersion < 20000 then
+    elseif addon.game == "CLASSIC" then
         iconReference.frame = _G.PlayerTalentFrame
         iconReference.size = 32
         iconReference.point = {
@@ -450,7 +450,7 @@ end
 
 -- { tab, talentIndex, name }
 local function learnClassicTalent(payload)
-    if addon.gameVersion > 20000 then return end
+    if addon.game ~= "CLASSIC" then return end
 
     local tab, talentIndex, name = unpack(payload)
     local result = LearnTalent(tab, talentIndex)
@@ -501,18 +501,15 @@ function addon.talents.functions.talent(element, validate, optional)
             return false
         end
 
-        -- TODO validate cataLevelLookup for overun, allow underrun for multi-spec chains
-
         talentIndex = lookup[talentData.tier][talentData.column]
 
         if talentIndex and validate then return true end
 
-        if addon.gameVersion > 40000 then
-            -- Return values don't match API docs/TWW, so used /dump GetTalentInfo(1,11) for Arms War
+        if addon.game == "CATA" then
             name, _, _, _, _, _, _, previewRankOrRank = GetTalentInfo(
                                                             talentData.tab,
                                                             talentIndex)
-        elseif addon.gameVersion > 30000 then
+        elseif addon.game == "WOTLK" then
             name, _, _, _, _, _, _, _, previewRankOrRank, _ = GetTalentInfo(
                                                                   talentData.tab,
                                                                   talentIndex)
@@ -522,7 +519,7 @@ function addon.talents.functions.talent(element, validate, optional)
         end
 
         if previewRankOrRank < talentData.rank then
-            if addon.gameVersion < 20000 then -- Classic doesn't have Preview Talents
+            if addon.game == "CLASSIC" then -- Classic doesn't have Preview Talents
                 tempData = {talentData.tab, talentIndex, name}
 
                 if optional then
@@ -573,7 +570,7 @@ function addon.talents.functions.talent(element, validate, optional)
 end
 
 function addon.talents.functions.pettalent(element, validate)
-    if addon.gameVersion < 30000 then return end
+    if addon.game ~= "WOTLK" then return end
 
     if type(element) == "string" then -- on parse
         local e = {pettalent = {}}
@@ -683,7 +680,7 @@ function addon.talents:UpdateSelectedGuide(key)
     return true
 end
 
-if addon.gameVersion < 40000 then
+if addon.game ~= "CATA" then
     talentTooltips.updateFunc = function(self)
         local tooltip = talentTooltips.data[self:GetID()]
         if not tooltip then return end

--- a/Talents.lua
+++ b/Talents.lua
@@ -753,11 +753,14 @@ local function DrawTalentLevels(talentIndex, numbers)
 
     -- If 5 levels of preview, overlaps with nearby
     if #numbers == 5 then
-        ht.levelHeader.text:SetFont(addon.font, 8, "OUTLINE")
+        ht.levelHeader.text:SetFont(addon.font, 7, "OUTLINE")
         ht.levelHeader:SetPoint("TOPLEFT", ht, -3, 0)
+    elseif #numbers == 4 then
+        ht.levelHeader.text:SetFont(addon.font, 9, "OUTLINE")
+        ht.levelHeader:SetPoint("TOPLEFT", ht, -1, 0)
     else
         ht.levelHeader.text:SetFont(addon.font, 10, "OUTLINE")
-        ht.levelHeader:SetPoint("TOPLEFT", ht, 0, 0)
+        ht.levelHeader:SetPoint("TOPLEFT", ht, 1, 0)
     end
 
     -- Ensure single number ends up as a string

--- a/Talents.lua
+++ b/Talents.lua
@@ -711,13 +711,13 @@ function addon.talents:DrawTalents()
     wipe(activeIndices)
     wipe(levelsForIndex)
 
+    local newHightlightTexture
     -- Create highlight frames and set data objects for later processing
     for upcomingTalent = (playerLevel + 1 - remainingPoints), advancedWarning do
 
         levelStep = guide.steps[upcomingTalent - guide.minLevel + 1]
 
         if levelStep then
-
             for _, element in ipairs(levelStep.elements) do
                 for _, talentData in ipairs(element.talent) do
 
@@ -736,14 +736,14 @@ function addon.talents:DrawTalents()
                         -- TODO Pre-seed tooltip to prevent delay
 
                         if not talentTooltips.highlights[talentIndex] then
-                            local ht = _G["PlayerTalentFrameTalent" .. talentIndex]:CreateTexture(
-                                           "$parent_LevelPreview", "BORDER")
+                            newHightlightTexture = _G["PlayerTalentFrameTalent" .. talentIndex]:CreateTexture(
+                                                       "$parent_LevelPreview", "BORDER")
 
-                            ht:SetTexture("Interface/Buttons/ButtonHilight-Square")
-                            ht:SetBlendMode("ADD")
-                            ht:SetAllPoints(_G["PlayerTalentFrameTalent" .. talentIndex .. "Slot"])
+                            newHightlightTexture:SetTexture("Interface/Buttons/ButtonHilight-Square")
+                            newHightlightTexture:SetBlendMode("ADD")
+                            newHightlightTexture:SetAllPoints(_G["PlayerTalentFrameTalent" .. talentIndex .. "Slot"])
 
-                            talentTooltips.highlights[talentIndex] = ht
+                            talentTooltips.highlights[talentIndex] = newHightlightTexture
                         end
 
                         setHighlightColor(talentIndex, upcomingTalent - playerLevel)

--- a/Talents.lua
+++ b/Talents.lua
@@ -530,7 +530,7 @@ function addon.talents.functions.talent(element, validate, optional)
                 return true, fmt("%s (%s %d)", _G.RANK, talentData.rank)
             end
 
-            -- Return -1 if not selected, check upstream to verify at least one #optional step talent chosen
+            -- Return false if not selected, check upstream to verify at least one #optional step talent chosen
             return false, fmt("%s (%s %d)", name, _G.RANK, talentData.rank)
         end
 

--- a/Talents.lua
+++ b/Talents.lua
@@ -528,7 +528,7 @@ function addon.talents.functions.talent(element, validate, optional)
                                     _G.COMMUNITIES_CHANNEL_DESCRIPTION_INSTRUCTIONS,
                                     name, _G.RANK, talentData.rank)
                 -- Handle in level step processing, if return value is rank from at least one optional step, continue
-                return true
+                return true, name
             end
             -- Return -1 if not selected, check upstream to verify at least one #optional step talent chosen
             return -1

--- a/Talents.lua
+++ b/Talents.lua
@@ -12,14 +12,18 @@ local EasyMenu = function(...)
     end
 end
 
-local fmt, sgmatch, strsplittable, strjoin = string.format, string.gmatch, strsplittable, string.join
+local fmt, sgmatch, strsplittable, strjoin = string.format, string.gmatch,
+                                             strsplittable, string.join
 local tonumber = tonumber
 local tinsert, tsort = tinsert, table.sort
 local UnitLevel = UnitLevel
-local GetPetTalentTree, GetUnspentTalentPoints, GetGroupPreviewTalentPointsSpent, AddPreviewTalentPoints,
-      UnitCharacterPoints = _G.GetPetTalentTree, _G.GetUnspentTalentPoints, _G.GetGroupPreviewTalentPointsSpent,
+local GetPetTalentTree, GetUnspentTalentPoints,
+      GetGroupPreviewTalentPointsSpent, AddPreviewTalentPoints,
+      UnitCharacterPoints = _G.GetPetTalentTree, _G.GetUnspentTalentPoints,
+                            _G.GetGroupPreviewTalentPointsSpent,
                             _G.AddPreviewTalentPoints, _G.UnitCharacterPoints
-local PanelTemplates_GetSelectedTab, PlayerTalentFrame = _G.PanelTemplates_GetSelectedTab, _G.PlayerTalentFrame
+local PanelTemplates_GetSelectedTab, PlayerTalentFrame =
+    _G.PanelTemplates_GetSelectedTab, _G.PlayerTalentFrame
 local BackdropTemplate = BackdropTemplateMixin and "BackdropTemplate"
 
 local L = addon.locale.Get
@@ -92,7 +96,8 @@ local function buildTalentGuidesMenu()
             if guide.pet == GetPetTalentTree() then
                 tinsert(menu, {
                     text = guide.name,
-                    tooltipTitle = fmt("%s: %s", _G.LEVEL_RANGE, guide.levelRange),
+                    tooltipTitle = fmt("%s: %s", _G.LEVEL_RANGE,
+                                       guide.levelRange),
                     notCheckable = 1,
                     disabled = disabled,
                     tooltipText = invalidReason,
@@ -107,7 +112,8 @@ local function buildTalentGuidesMenu()
             end
         end
     else
-        tinsert(menu, {text = L("Available Guides"), isTitle = 1, notCheckable = 1})
+        tinsert(menu,
+                {text = L("Available Guides"), isTitle = 1, notCheckable = 1})
 
         for key, guide in pairs(addon.talents.guides) do
 
@@ -134,7 +140,9 @@ local function buildTalentGuidesMenu()
                 func = function(_, arg1)
                     addon.talents:UpdateSelectedGuide(arg1)
 
-                    if addon.talents:ProcessTalents('validate') then addon.talents:DrawTalents() end
+                    if addon.talents:ProcessTalents('validate') then
+                        addon.talents:DrawTalents()
+                    end
                 end
             })
         end
@@ -142,16 +150,30 @@ local function buildTalentGuidesMenu()
 
     tinsert(menu, {text = "", notCheckable = 1, isTitle = 1})
 
-    tinsert(menu, {text = _G.APPLY, notCheckable = 1, func = function() addon.talents:ProcessTalents() end})
+    tinsert(menu, {
+        text = _G.APPLY,
+        notCheckable = 1,
+        func = function() addon.talents:ProcessTalents() end
+    })
 
-    tinsert(menu, {text = _G.GAMEOPTIONS_MENU, notCheckable = 1, func = function() addon.settings.OpenSettings() end})
+    tinsert(menu, {
+        text = _G.GAMEOPTIONS_MENU,
+        notCheckable = 1,
+        func = function() addon.settings.OpenSettings() end
+    })
 
-    tinsert(menu, {text = _G.CLOSE, notCheckable = 1, func = function(self) self:Hide() end})
+    tinsert(menu, {
+        text = _G.CLOSE,
+        notCheckable = 1,
+        func = function(self) self:Hide() end
+    })
 
     return menu
 end
 
-function addon.talents:IsSupported() return self.guides and next(self.guides) ~= nil and compatible end
+function addon.talents:IsSupported()
+    return self.guides and next(self.guides) ~= nil and compatible
+end
 
 function addon.talents:Setup()
     if not addon.settings.profile.enableTalentGuides then return end
@@ -162,7 +184,8 @@ function addon.talents:Setup()
 
     self:UpdateSelectedGuide(RXPCData.activeTalentGuide)
 
-    if tonumber(GetCVar("previewTalents")) == 0 and addon.gameVersion > 30000 and addon.settings.profile.previewTalents then
+    if tonumber(GetCVar("previewTalents")) == 0 and addon.gameVersion > 30000 and
+        addon.settings.profile.previewTalents then
         -- Talents are enabled in RXP, so match client
         -- This only lasts per session, does not persist in-game setting
         SetCVar("previewTalents", 1)
@@ -172,16 +195,19 @@ end
 function addon.talents:ADDON_LOADED(_, loadedAddon)
     -- Talent frame/globals get loaded on demand when it's first opened
     if loadedAddon == "Blizzard_TalentUI" then
-        _G.PlayerTalentFrame:HookScript("OnShow", function() addon.talents:HookUI() end)
+        _G.PlayerTalentFrame:HookScript("OnShow",
+                                        function() addon.talents:HookUI() end)
 
-        _G.PlayerTalentFrame:HookScript("OnUpdate", function() self:DrawTalents() end)
+        _G.PlayerTalentFrame:HookScript("OnUpdate",
+                                        function() self:DrawTalents() end)
 
         PlayerTalentFrame = _G.PlayerTalentFrame
 
         self:BuildIndexLookup()
     elseif loadedAddon == "Talented" then
         compatible = false
-        addon.comms.PrettyPrint(L("Talented detected, please disable for talent guide functionality")) -- TODO locale
+        addon.comms.PrettyPrint(L(
+                                    "Talented detected, please disable for talent guide functionality")) -- TODO locale
     end
 end
 
@@ -194,7 +220,9 @@ function addon.talents:UpdateTalentsButton()
 
         -- Offset RXP button as much as Tab2 is from Tab1
         _, _, _, _, iconReference.offsetY = _G.PlayerSpecTab3:GetPoint()
-        iconReference.point = {"TOP", iconReference.frame, "BOTTOM", 0, iconReference.offsetY}
+        iconReference.point = {
+            "TOP", iconReference.frame, "BOTTOM", 0, iconReference.offsetY
+        }
 
     elseif _G.PlayerSpecTab2 and _G.PlayerSpecTab2:IsShown() then -- Dual spec non-hunter
         iconReference.frame = _G.PlayerSpecTab2
@@ -203,19 +231,27 @@ function addon.talents:UpdateTalentsButton()
         -- Offset RXP button as much as Tab2 is from Tab1
         _, _, _, _, iconReference.offsetY = _G.PlayerSpecTab2:GetPoint()
 
-        iconReference.point = {"TOP", iconReference.frame, "BOTTOM", 0, iconReference.offsetY}
+        iconReference.point = {
+            "TOP", iconReference.frame, "BOTTOM", 0, iconReference.offsetY
+        }
     elseif addon.game == "CATA" and _G.PlayerSpecTab1 then -- Cata, non dual-spec non-hunter
         iconReference.frame = _G.PlayerTalentFrame
         iconReference.size = 32
-        iconReference.point = {"TOPLEFT", iconReference.frame, "TOPRIGHT", 0, -65}
+        iconReference.point = {
+            "TOPLEFT", iconReference.frame, "TOPRIGHT", 0, -65
+        }
     elseif _G.PlayerSpecTab1 then -- Wrath, non dual-spec non-hunter
         iconReference.frame = _G.PlayerTalentFrame
         iconReference.size = 32
-        iconReference.point = {"TOPLEFT", iconReference.frame, "TOPRIGHT", -32, -65}
+        iconReference.point = {
+            "TOPLEFT", iconReference.frame, "TOPRIGHT", -32, -65
+        }
     elseif addon.gameVersion < 20000 then
         iconReference.frame = _G.PlayerTalentFrame
         iconReference.size = 32
-        iconReference.point = {"TOPLEFT", iconReference.frame, "TOPRIGHT", -32, -65}
+        iconReference.point = {
+            "TOPLEFT", iconReference.frame, "TOPRIGHT", -32, -65
+        }
         -- elseif Retail
     else
         return nil
@@ -240,7 +276,9 @@ function addon.talents:UpdateTalentsButton()
         self.talentsButton = button
 
         button:SetScript("OnEnter", function(this)
-            if this:IsForbidden() or GameTooltip:IsForbidden() then return end
+            if this:IsForbidden() or GameTooltip:IsForbidden() then
+                return
+            end
             GameTooltip:SetOwner(this, "ANCHOR_TOPLEFT", iconReference.size, 0)
             GameTooltip:ClearLines()
 
@@ -248,16 +286,20 @@ function addon.talents:UpdateTalentsButton()
             if guide then
                 GameTooltip:AddLine(guide.name)
                 GameTooltip:AddLine(L("Left click to apply talents"), 0, 1, 0)
-                GameTooltip:AddLine(fmt("%s: %d - %d", _G.LEVEL_RANGE, guide.minLevel, guide.maxLevel), 1, 1, 1)
+                GameTooltip:AddLine(fmt("%s: %d - %d", _G.LEVEL_RANGE,
+                                        guide.minLevel, guide.maxLevel), 1, 1, 1)
             else
-                GameTooltip:AddLine(L("Welcome to RestedXP Guides\nRight click to pick a guide"))
+                GameTooltip:AddLine(L(
+                                        "Welcome to RestedXP Guides\nRight click to pick a guide"))
             end
 
             GameTooltip:Show()
         end)
 
         button:SetScript("OnLeave", function(this)
-            if this:IsForbidden() or GameTooltip:IsForbidden() then return end
+            if this:IsForbidden() or GameTooltip:IsForbidden() then
+                return
+            end
             GameTooltip:Hide()
         end)
 
@@ -281,17 +323,21 @@ function addon.talents:HookUI()
     end
 
     if not talentTooltips.hooked then
-        hooksecurefunc("PlayerTalentFrameTalent_OnEnter", talentTooltips.updateFunc)
+        hooksecurefunc("PlayerTalentFrameTalent_OnEnter",
+                       talentTooltips.updateFunc)
 
         talentTooltips.hooked = true
     end
 
     if not self.menuFrame then
-        self.menuFrame = CreateFrame("Frame", "RXP_TalentsMenuFrame", self.talentsButton, "UIDropDownMenuTemplate")
+        self.menuFrame = CreateFrame("Frame", "RXP_TalentsMenuFrame",
+                                     self.talentsButton,
+                                     "UIDropDownMenuTemplate")
 
         self.talentsButton:SetScript("OnMouseUp", function(_, click)
             if click == "RightButton" then
-                EasyMenu(buildTalentGuidesMenu(), self.menuFrame, self.talentsButton, 0, 0, "MENU", 1)
+                EasyMenu(buildTalentGuidesMenu(), self.menuFrame,
+                         self.talentsButton, 0, 0, "MENU", 1)
             else
                 self:ProcessTalents()
             end
@@ -337,7 +383,8 @@ function addon.talents:ParseGuide(text)
         elseif currentStep > 0 then -- Parse metadata tags first
 
             -- Parse function calls
-            parseSuccess = line:gsub("^[%.#](%S+)%s*(.*)", function(command, lineArgs)
+            parseSuccess = line:gsub("^[%.#](%S+)%s*(.*)",
+                                     function(command, lineArgs)
                 if self.functions[command] then
                     -- print("Processing guide command", command, "with (", lineArgs, ")")
                     local element = self.functions[command](lineArgs)
@@ -352,8 +399,10 @@ function addon.talents:ParseGuide(text)
                 elseif command == "optional" then -- Allowlisted step flags, preserve typo handling
                     step[command] = true
                 else
-                    addon.error(L("Error parsing guide") .. " " .. (guide.name or 'Unknown') ..
-                                    ": Invalid function call (." .. command .. ")\n" .. line)
+                    addon.error(L("Error parsing guide") .. " " ..
+                                    (guide.name or 'Unknown') ..
+                                    ": Invalid function call (." .. command ..
+                                    ")\n" .. line)
                 end
             end)
 
@@ -362,13 +411,16 @@ function addon.talents:ParseGuide(text)
             parseSuccess = line:gsub("^#(%S+)%s*(.*)", function(tag, value)
                 -- print("Parsing guide tag at", linenumber, tag, value)
                 -- Set metadata without overwriting
-                if tag and tag ~= "" and not guide[tag] then guide[tag] = value end
+                if tag and tag ~= "" and not guide[tag] then
+                    guide[tag] = value
+                end
             end)
 
         end
 
         if not parseSuccess or internalParseFailure then
-            addon.comms.PrettyPrint("%s: Critical failure for $s", L("Error parsing guide"),
+            addon.comms.PrettyPrint("%s: Critical failure for $s",
+                                    L("Error parsing guide"),
                                     guide.name or guide.key or 'Unknown')
 
             return
@@ -377,17 +429,21 @@ function addon.talents:ParseGuide(text)
 
     -- Ensure guide tags exist with good defaults
     if not guide.name then
-        addon.comms.PrettyPrint("%s: Missing #%s", L("Error parsing guide"), "name")
+        addon.comms.PrettyPrint("%s: Missing #%s", L("Error parsing guide"),
+                                "name")
         return
     end
 
     guide.minLevel = tonumber(guide.minLevel) or 10
     guide.maxLevel = tonumber(guide.maxLevel) or addon.talents.maxLevel
     guide.levelRange = fmt("%d-%d", guide.minLevel, guide.maxLevel)
-    guide.description = guide.description or fmt("%s - %s (%s)", addon.player.localeClass, guide.name, guide.levelRange)
+    guide.description = guide.description or
+                            fmt("%s - %s (%s)", addon.player.localeClass,
+                                guide.name, guide.levelRange)
     guide.displayname = guide.displayname or guide.description
     guide.key = guide.key or fmt("%s - %s", addon.player.class, guide.name)
-    guide.nextKey = guide.next and fmt("%s - %s", addon.player.class, guide.next)
+    guide.nextKey = guide.next and
+                        fmt("%s - %s", addon.player.class, guide.next)
 
     return guide
 end
@@ -417,8 +473,12 @@ function addon.talents.functions.talent(element, validate, optional)
 
         local tab, tier, column, rank = strsplit(',', args)
         -- print("Inserting talent", arg)
-        tinsert(e.talent,
-                {tab = tonumber(tab), tier = tonumber(tier), column = tonumber(column), rank = tonumber(rank) or 1})
+        tinsert(e.talent, {
+            tab = tonumber(tab),
+            tier = tonumber(tier),
+            column = tonumber(column),
+            rank = tonumber(rank) or 1
+        })
 
         return e
     end
@@ -431,10 +491,12 @@ function addon.talents.functions.talent(element, validate, optional)
     for _, talentData in ipairs(element.talent) do
         lookup = indexLookup['player'][talentData.tab]
 
-        if not (lookup and lookup[talentData.tier] and lookup[talentData.tier][talentData.column]) then
+        if not (lookup and lookup[talentData.tier] and
+            lookup[talentData.tier][talentData.column]) then
 
-            addon.comms.PrettyPrint("Invalid talentIndex lookup for [%d][%d][%d]", talentData.tab, talentData.tier,
-                                    talentData.column)
+            addon.comms.PrettyPrint(
+                "Invalid talentIndex lookup for [%d][%d][%d]", talentData.tab,
+                talentData.tier, talentData.column)
             return false
         end
 
@@ -446,11 +508,16 @@ function addon.talents.functions.talent(element, validate, optional)
 
         if addon.gameVersion > 40000 then
             -- Return values don't match API docs/TWW, so used /dump GetTalentInfo(1,11) for Arms War
-            name, _, _, _, _, _, _, previewRankOrRank = GetTalentInfo(talentData.tab, talentIndex)
+            name, _, _, _, _, _, _, previewRankOrRank = GetTalentInfo(
+                                                            talentData.tab,
+                                                            talentIndex)
         elseif addon.gameVersion > 30000 then
-            name, _, _, _, _, _, _, _, previewRankOrRank, _ = GetTalentInfo(talentData.tab, talentIndex)
+            name, _, _, _, _, _, _, _, previewRankOrRank, _ = GetTalentInfo(
+                                                                  talentData.tab,
+                                                                  talentIndex)
         else
-            name, _, _, _, previewRankOrRank = GetTalentInfo(talentData.tab, talentIndex)
+            name, _, _, _, previewRankOrRank =
+                GetTalentInfo(talentData.tab, talentIndex)
         end
 
         if previewRankOrRank < talentData.rank then
@@ -461,11 +528,13 @@ function addon.talents.functions.talent(element, validate, optional)
                 if optional then
                     -- TODO user input timing, noop prompt informing of action/options
                     -- TODO handle replaying, avoid blocking on user action if talent exists in any optional blocks
-                    addon.comms.PrettyPrint("%s - (%s) %s (%s %d)", _G.TRADE_SKILLS_LEARNED_TAB,
-                                            _G.COMMUNITIES_CHANNEL_DESCRIPTION_INSTRUCTIONS, name, _G.RANK,
-                                            talentData.rank)
+                    addon.comms.PrettyPrint("%s - (%s) %s (%s %d)",
+                                            _G.TRADE_SKILLS_LEARNED_TAB,
+                                            _G.COMMUNITIES_CHANNEL_DESCRIPTION_INSTRUCTIONS,
+                                            name, _G.RANK, talentData.rank)
                 else
-                    addon.comms:ConfirmChoice("RXPTalentPrompt", prompt, learnClassicTalent, d)
+                    addon.comms:ConfirmChoice("RXPTalentPrompt", prompt,
+                                              learnClassicTalent, d)
                 end
 
                 -- Stop as soon as first learning prompt, not a blocking dialog
@@ -477,18 +546,22 @@ function addon.talents.functions.talent(element, validate, optional)
 
                 -- Verify training actually worked, there's no return value from Preview
                 if before == GetGroupPreviewTalentPointsSpent() then
-                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN, name))
+                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN,
+                                    name))
                     return false
                 end
 
-                addon.comms.PrettyPrint("%s - %s (%s %d)", _G.PREVIEW, name, _G.RANK, talentData.rank)
+                addon.comms.PrettyPrint("%s - %s (%s %d)", _G.PREVIEW, name,
+                                        _G.RANK, talentData.rank)
             else
                 -- TODO if optional
                 if LearnTalent(talentData.tab, talentIndex) then
-                    addon.comms.PrettyPrint("%s - %s (%s %d)", _G.TRADE_SKILLS_LEARNED_TAB, name, _G.RANK,
-                                            talentData.rank)
+                    addon.comms.PrettyPrint("%s - %s (%s %d)",
+                                            _G.TRADE_SKILLS_LEARNED_TAB, name,
+                                            _G.RANK, talentData.rank)
                 else
-                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN, name))
+                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN,
+                                    name))
                     return false
                 end
             end
@@ -511,8 +584,12 @@ function addon.talents.functions.pettalent(element, validate)
         local tab, tier, column, rank = strsplit(',', args)
 
         -- print("Inserting pettalent", arg)
-        tinsert(e.pettalent,
-                {tab = tonumber(tab), tier = tonumber(tier), column = tonumber(column), rank = tonumber(rank) or 1})
+        tinsert(e.pettalent, {
+            tab = tonumber(tab),
+            tier = tonumber(tier),
+            column = tonumber(column),
+            rank = tonumber(rank) or 1
+        })
 
         return e
     end
@@ -524,10 +601,12 @@ function addon.talents.functions.pettalent(element, validate)
     for _, talentData in pairs(element.pettalent) do
         lookup = indexLookup[GetPetTalentTree()][talentData.tab]
 
-        if not (lookup and lookup[talentData.tier] and lookup[talentData.tier][talentData.column]) then
+        if not (lookup and lookup[talentData.tier] and
+            lookup[talentData.tier][talentData.column]) then
 
-            addon.comms.PrettyPrint("Invalid pet talentIndex lookup for [%d][%d][%d]", talentData.tab, talentData.tier,
-                                    talentData.column)
+            addon.comms.PrettyPrint(
+                "Invalid pet talentIndex lookup for [%d][%d][%d]",
+                talentData.tab, talentData.tier, talentData.column)
             return false
         end
 
@@ -535,27 +614,35 @@ function addon.talents.functions.pettalent(element, validate)
 
         if talentIndex and validate then return true end
 
-        name, _, _, _, _, _, _, _, previewRankOrRank, _ = GetTalentInfo(talentData.tab, talentIndex, nil, true)
+        name, _, _, _, _, _, _, _, previewRankOrRank, _ = GetTalentInfo(
+                                                              talentData.tab,
+                                                              talentIndex, nil,
+                                                              true)
 
         -- TODO handle off-plan talents
         if name and previewRankOrRank < talentData.rank then
             if addon.settings.profile.previewTalents then
                 local before = GetGroupPreviewTalentPointsSpent(true, 1)
-                AddPreviewTalentPoints(talentData.tab, talentIndex, 1, true, PlayerTalentFrame.talentGroup)
+                AddPreviewTalentPoints(talentData.tab, talentIndex, 1, true,
+                                       PlayerTalentFrame.talentGroup)
 
                 -- Verify training actually worked, there's no return value from Preview
                 if before == GetGroupPreviewTalentPointsSpent(true, 1) then
-                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN, name))
+                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN,
+                                    name))
                     return false
                 end
 
-                addon.comms.PrettyPrint("%s - %s (%s %d)", _G.PREVIEW, name, _G.RANK, talentData.rank)
+                addon.comms.PrettyPrint("%s - %s (%s %d)", _G.PREVIEW, name,
+                                        _G.RANK, talentData.rank)
             else
                 if LearnTalent(talentData.tab, talentIndex, true) then
-                    addon.comms.PrettyPrint("%s - %s (%s %d)", _G.TRADE_SKILLS_LEARNED_TAB, name, _G.RANK,
-                                            talentData.rank)
+                    addon.comms.PrettyPrint("%s - %s (%s %d)",
+                                            _G.TRADE_SKILLS_LEARNED_TAB, name,
+                                            _G.RANK, talentData.rank)
                 else
-                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN, name))
+                    addon.error(fmt("%s - %s", _G.ERR_TALENT_FAILED_UNKNOWN,
+                                    name))
                     return false
                 end
             end
@@ -581,7 +668,8 @@ function addon.talents:UpdateSelectedGuide(key)
     if not self.guides[key] then return end
 
     if UnitLevel("player") < self.guides[key].minLevel then
-        addon.comms.PrettyPrint(L("Too low for %s"), self.guides[key].displayname)
+        addon.comms.PrettyPrint(L("Too low for %s"),
+                                self.guides[key].displayname)
 
         return
     end
@@ -608,19 +696,27 @@ if addon.gameVersion < 40000 then
     end
 else
     talentTooltips.updateFunc = function(talentIndexFrame)
-        if not (talentIndexFrame.RXP and talentIndexFrame.RXP.levels) then return end
+        if not (talentIndexFrame.RXP and talentIndexFrame.RXP.levels) then
+            return
+        end
 
         -- Because drawing at tooltip time, extra step required to order it vs everytime in drawTalents
         local sorted_levels = {}
-        for l, _ in pairs(talentIndexFrame.RXP.levels) do tinsert(sorted_levels, l) end
+        for l, _ in pairs(talentIndexFrame.RXP.levels) do
+            tinsert(sorted_levels, l)
+        end
 
         tsort(sorted_levels)
 
         local levelsCsv = ''
-        for _, level in pairs(sorted_levels) do levelsCsv = fmt('%s%d ', levelsCsv, level) end
+        for _, level in pairs(sorted_levels) do
+            levelsCsv = fmt('%s%d ', levelsCsv, level)
+        end
 
         -- Only calculate string on tooltip hover, vs every DrawTalents like on Era
-        local rxpTooltip = fmt("%s\n%s%s: %s %s|r", talentIndexFrame.RXP.tooltipTextHeader, addon.colors.tooltip,
+        local rxpTooltip = fmt("%s\n%s%s: %s %s|r",
+                               talentIndexFrame.RXP.tooltipTextHeader,
+                               addon.colors.tooltip,
                                _G.TRADE_SKILLS_LEARNED_TAB, _G.LEVEL, levelsCsv)
         -- Handle refreshing of UI
         GameTooltip:AddLine(rxpTooltip, 1, 1, 1)
@@ -636,7 +732,8 @@ local function DrawTalentLevels(talentIndex, numbers)
     if not ht then return end
 
     if not ht.levelHeader then
-        ht.levelHeader = CreateFrame("Frame", "$parent_levelText", _G["PlayerTalentFrameTalent" .. talentIndex],
+        ht.levelHeader = CreateFrame("Frame", "$parent_levelText",
+                                     _G["PlayerTalentFrameTalent" .. talentIndex],
                                      BackdropTemplate)
 
         ht.levelHeader:SetPoint("TOPLEFT", ht, 0, 0)
@@ -710,13 +807,15 @@ function addon.talents:DrawTalents()
     local remainingPoints, levelStep, talentIndex
 
     if GetUnspentTalentPoints then
-        remainingPoints = GetUnspentTalentPoints() - GetGroupPreviewTalentPointsSpent()
+        remainingPoints = GetUnspentTalentPoints() -
+                              GetGroupPreviewTalentPointsSpent()
     else
         remainingPoints = UnitCharacterPoints("player")
     end
 
     local playerLevel = UnitLevel("player")
-    local advancedWarning = playerLevel + addon.settings.profile.upcomingTalentCount
+    local advancedWarning = playerLevel +
+                                addon.settings.profile.upcomingTalentCount
     wipe(talentTooltips.data)
 
     -- Track state better than with Blizz frame re-use
@@ -724,44 +823,59 @@ function addon.talents:DrawTalents()
     wipe(levelsForIndex)
 
     local newHightlightTexture, tooltipPrefix
-    RXPD = {}
+
     -- Create highlight frames and set data objects for later processing
     for upcomingTalent = (playerLevel + 1 - remainingPoints), advancedWarning do
 
         levelStep = guide.steps[upcomingTalent - guide.minLevel + 1]
 
         if levelStep then
-            tooltipPrefix = levelStep.optional and _G.COMMUNITIES_CHANNEL_DESCRIPTION_INSTRUCTIONS or _G.TRADE_SKILLS_LEARNED_TAB
-            RXPD[upcomingTalent - guide.minLevel + 1] = levelStep
+            tooltipPrefix = levelStep.optional and
+                                _G.COMMUNITIES_CHANNEL_DESCRIPTION_INSTRUCTIONS or
+                                _G.TRADE_SKILLS_LEARNED_TAB
+
             for _, element in ipairs(levelStep.elements) do
                 for _, talentData in ipairs(element.talent) do
 
-                    talentIndex = indexLookup['player'][talentData.tab][talentData.tier][talentData.column]
+                    talentIndex =
+                        indexLookup['player'][talentData.tab][talentData.tier][talentData.column]
 
                     if currentTab == talentData.tab then
                         activeIndices[talentIndex] = talentData.tab
 
-                        talentTooltips.data[talentIndex] = talentTooltips.data[talentIndex] or
-                                                               fmt("\n%s - %s", addon.title, guide.name)
+                        talentTooltips.data[talentIndex] =
+                            talentTooltips.data[talentIndex] or
+                                fmt("\n%s - %s", addon.title, guide.name)
 
-                        talentTooltips.data[talentIndex] = fmt("%s\n%s%s: %s %d|r", talentTooltips.data[talentIndex],
-                                                               addon.colors.tooltip, tooltipPrefix,
-                                                               _G.LEVEL, upcomingTalent)
+                        talentTooltips.data[talentIndex] = fmt(
+                                                               "%s\n%s%s: %s %d|r",
+                                                               talentTooltips.data[talentIndex],
+                                                               addon.colors
+                                                                   .tooltip,
+                                                               tooltipPrefix,
+                                                               _G.LEVEL,
+                                                               upcomingTalent)
 
                         -- TODO Pre-seed tooltip to prevent delay
 
                         if not talentTooltips.highlights[talentIndex] then
-                            newHightlightTexture = _G["PlayerTalentFrameTalent" .. talentIndex]:CreateTexture(
-                                                       "$parent_LevelPreview", "BORDER")
+                            newHightlightTexture =
+                                _G["PlayerTalentFrameTalent" .. talentIndex]:CreateTexture(
+                                    "$parent_LevelPreview", "BORDER")
 
-                            newHightlightTexture:SetTexture("Interface/Buttons/ButtonHilight-Square")
+                            newHightlightTexture:SetTexture(
+                                "Interface/Buttons/ButtonHilight-Square")
                             newHightlightTexture:SetBlendMode("ADD")
-                            newHightlightTexture:SetAllPoints(_G["PlayerTalentFrameTalent" .. talentIndex .. "Slot"])
+                            newHightlightTexture:SetAllPoints(
+                                _G["PlayerTalentFrameTalent" .. talentIndex ..
+                                    "Slot"])
 
-                            talentTooltips.highlights[talentIndex] = newHightlightTexture
+                            talentTooltips.highlights[talentIndex] =
+                                newHightlightTexture
                         end
 
-                        setHighlightColor(talentIndex, upcomingTalent - playerLevel)
+                        setHighlightColor(talentIndex,
+                                          upcomingTalent - playerLevel)
 
                         if levelsForIndex[talentIndex] then
                             tinsert(levelsForIndex[talentIndex], upcomingTalent)
@@ -785,7 +899,9 @@ function addon.talents:DrawTalents()
             DrawTalentLevels(index, levelsForIndex[index])
 
             if not ht:IsShown() then ht:Show() end
-            if not ht.levelHeader:IsShown() then ht.levelHeader:Show() end
+            if not ht.levelHeader:IsShown() then
+                ht.levelHeader:Show()
+            end
         else
             if ht:IsShown() then ht:Hide() end
             if ht.levelHeader:IsShown() then ht.levelHeader:Hide() end
@@ -807,21 +923,28 @@ function addon.talents:BuildIndexLookup()
 
     -- print("BuildIndexLookup() looping", kind)
 
-    for tabIndex = 1, _G.GetNumTalentTabs(nil, PlayerTalentFrame.pet, PlayerTalentFrame.talentGroup) do
+    for tabIndex = 1, _G.GetNumTalentTabs(nil, PlayerTalentFrame.pet,
+                                          PlayerTalentFrame.talentGroup) do
         indexLookup[kind][tabIndex] = {}
 
-        for talentIndex = 1, _G.GetNumTalents(tabIndex, nil, PlayerTalentFrame.pet, PlayerTalentFrame.talentGroup) do
-            name, _, tier, column = GetTalentInfo(tabIndex, talentIndex, nil, PlayerTalentFrame.pet,
+        for talentIndex = 1, _G.GetNumTalents(tabIndex, nil,
+                                              PlayerTalentFrame.pet,
+                                              PlayerTalentFrame.talentGroup) do
+            name, _, tier, column = GetTalentInfo(tabIndex, talentIndex, nil,
+                                                  PlayerTalentFrame.pet,
                                                   PlayerTalentFrame.talentGroup)
             if name then
-                indexLookup[kind][tabIndex][tier] = indexLookup[kind][tabIndex][tier] or {}
+                indexLookup[kind][tabIndex][tier] =
+                    indexLookup[kind][tabIndex][tier] or {}
                 indexLookup[kind][tabIndex][tier][column] = talentIndex
             end
 
         end
     end
 
-    if indexLookup[kind][1] and indexLookup[kind][1][1] then indexLookup[kind].initialized = true end
+    if indexLookup[kind][1] and indexLookup[kind][1][1] then
+        indexLookup[kind].initialized = true
+    end
 end
 
 function addon.talents:ProcessTalents(validate)
@@ -835,7 +958,9 @@ function addon.talents:ProcessTalents(validate)
 
     if not guide then return end
 
-    if validate and addon.settings.profile.debug then addon.comms.PrettyPrint("Validating %s", guide.displayname) end
+    if validate and addon.settings.profile.debug then
+        addon.comms.PrettyPrint("Validating %s", guide.displayname)
+    end
 
     if playerLevel < guide.minLevel and not validate then
         addon.comms.PrettyPrint(L("Too low for %s"), guide.displayname) --
@@ -848,7 +973,8 @@ function addon.talents:ProcessTalents(validate)
     end
 
     if addon.game == "CATA" then
-        if _G.PanelTemplates_GetSelectedTab(PlayerTalentFrame) == _G.GLYPH_TALENT_TAB then
+        if _G.PanelTemplates_GetSelectedTab(PlayerTalentFrame) ==
+            _G.GLYPH_TALENT_TAB then
             _G["PlayerTalentFrameTab" .. _G.TALENTS_TAB]:Click()
         end
         -- Cata uses gives summary of trees on fresh 10/respec "View Talent Trees"
@@ -864,16 +990,20 @@ function addon.talents:ProcessTalents(validate)
             if firstTalentTab > -1 then break end
 
             for _, element in ipairs(step.elements) do
-                if element.talent and element.talent[1] and element.talent[1].tab then
+                if element.talent and element.talent[1] and
+                    element.talent[1].tab then
                     firstTalentTab = element.talent[1].tab
                     break
                 end
             end
         end
 
-        local firstTalentTabButton = _G["PlayerTalentFramePanel" .. firstTalentTab .. "SelectTreeButton"]
+        local firstTalentTabButton = _G["PlayerTalentFramePanel" ..
+                                         firstTalentTab .. "SelectTreeButton"]
         if firstTalentTabButton then
-            if firstTalentTabButton:IsShown() then firstTalentTabButton:Click() end
+            if firstTalentTabButton:IsShown() then
+                firstTalentTabButton:Click()
+            end
         else
             -- Failure to get first tab, panic?
         end
@@ -885,7 +1015,8 @@ function addon.talents:ProcessTalents(validate)
         stepLevel = guide.minLevel + stepNum - 1
 
         if GetUnspentTalentPoints then
-            remainingPoints = GetUnspentTalentPoints() - GetGroupPreviewTalentPointsSpent()
+            remainingPoints = GetUnspentTalentPoints() -
+                                  GetGroupPreviewTalentPointsSpent()
         else
             remainingPoints = UnitCharacterPoints("player")
         end
@@ -895,7 +1026,8 @@ function addon.talents:ProcessTalents(validate)
                 addon.comms.PrettyPrint(L("Reached maximum level for guide"))
 
                 if self:UpdateSelectedGuide(guide.nextKey) then
-                    addon.comms.PrettyPrint(L("Loaded next guide, %s"), guide.next)
+                    addon.comms.PrettyPrint(L("Loaded next guide, %s"),
+                                            guide.next)
                 end
             end
 
@@ -910,11 +1042,14 @@ function addon.talents:ProcessTalents(validate)
                 -- print("Evaluating tag", tag)
                 if self.functions[tag] then
                     -- print("Executing tag function", tag)
-                    result = self.functions[tag](element, validate, step.optional)
+                    result = self.functions[tag](element, validate,
+                                                 step.optional)
                 else
                     result = false
-                    addon.error(L("Error parsing guide") .. " " .. (guide.name or 'Unknown') ..
-                                    ": Invalid function call (." .. tag .. ")\n" .. stepNum)
+                    addon.error(L("Error parsing guide") .. " " ..
+                                    (guide.name or 'Unknown') ..
+                                    ": Invalid function call (." .. tag .. ")\n" ..
+                                    stepNum)
                 end
 
                 -- Exit processing if error found
@@ -942,7 +1077,9 @@ function addon.talents:ProcessPetTalents(validate)
 
     if not guide or not guide.pet then return end
 
-    if validate and addon.settings.profile.debug then addon.comms.PrettyPrint("Validating %s", guide.displayname) end
+    if validate and addon.settings.profile.debug then
+        addon.comms.PrettyPrint("Validating %s", guide.displayname)
+    end
 
     if playerLevel < guide.minLevel and not validate then
         addon.comms.PrettyPrint(L("Too low for %s"), guide.displayname) --
@@ -957,7 +1094,8 @@ function addon.talents:ProcessPetTalents(validate)
     local remainingPoints
 
     for stepNum, step in ipairs(guide.steps) do
-        remainingPoints = GetUnspentTalentPoints(nil, true) - GetGroupPreviewTalentPointsSpent(true, 1)
+        remainingPoints = GetUnspentTalentPoints(nil, true) -
+                              GetGroupPreviewTalentPointsSpent(true, 1)
 
         if remainingPoints == 0 then
             if not validate and playerLevel == guide.maxLevel then
@@ -975,16 +1113,20 @@ function addon.talents:ProcessPetTalents(validate)
                 -- print("Evaluating tag", tag)
                 if self.functions[tag] then
                     -- print("Executing tag function", tag)
-                    result = self.functions[tag](element, validate, step.optional)
+                    result = self.functions[tag](element, validate,
+                                                 step.optional)
                 else
                     result = false
-                    addon.error(L("Error parsing guide") .. " " .. (guide.name or 'Unknown') ..
-                                    ": Invalid function call (." .. tag .. ")\n" .. stepNum)
+                    addon.error(L("Error parsing guide") .. " " ..
+                                    (guide.name or 'Unknown') ..
+                                    ": Invalid function call (." .. tag .. ")\n" ..
+                                    stepNum)
                 end
 
                 if result == false then
                     if addon.settings.profile.debug then
-                        addon.comms.PrettyPrint("Aborting processing at step %d", stepNum)
+                        addon.comms.PrettyPrint(
+                            "Aborting processing at step %d", stepNum)
                     end
                     return
                 end
@@ -1004,18 +1146,25 @@ local function cataDrawTalentLevels(talentIndexFrameName, levels)
 
     if not talentIndexFrame.levelHeader then
         local anchor = _G[talentIndexFrameName .. 'IconOverlay']
-        talentIndexFrame.levelHeader = CreateFrame("Frame", "$parent_RXPLevelText", anchor or talentIndexFrame,
+        talentIndexFrame.levelHeader = CreateFrame("Frame",
+                                                   "$parent_RXPLevelText",
+                                                   anchor or talentIndexFrame,
                                                    BackdropTemplate)
 
-        talentIndexFrame.levelHeader:SetPoint("BOTTOMLEFT", talentIndexFrame, "TOPLEFT", 0, -4)
-        talentIndexFrame.levelHeader.text = talentIndexFrame.levelHeader:CreateFontString(nil, "OVERLAY")
+        talentIndexFrame.levelHeader:SetPoint("BOTTOMLEFT", talentIndexFrame,
+                                              "TOPLEFT", 0, -4)
+        talentIndexFrame.levelHeader.text =
+            talentIndexFrame.levelHeader:CreateFontString(nil, "OVERLAY")
 
         talentIndexFrame.levelHeader.text:ClearAllPoints()
-        talentIndexFrame.levelHeader.text:SetPoint("LEFT", talentIndexFrame.levelHeader, 0, 0)
+        talentIndexFrame.levelHeader.text:SetPoint("LEFT",
+                                                   talentIndexFrame.levelHeader,
+                                                   0, 0)
         talentIndexFrame.levelHeader.text:SetJustifyH("LEFT")
         talentIndexFrame.levelHeader.text:SetJustifyV("MIDDLE")
 
-        talentIndexFrame.levelHeader.text:SetTextColor(unpack(addon.activeTheme.textColor))
+        talentIndexFrame.levelHeader.text:SetTextColor(
+            unpack(addon.activeTheme.textColor))
         talentIndexFrame.levelHeader.text:SetFont(addon.font, 8, "OUTLINE")
     end
 
@@ -1030,26 +1179,32 @@ local function cataDrawTalentLevels(talentIndexFrameName, levels)
     -- If 5 levels of preview, overlaps with nearby
     if #sorted_levels < 4 then
         -- talentIndexFrame.levelHeader.text:SetFont(addon.font, 8, "OUTLINE")
-        talentIndexFrame.levelHeader:SetPoint("BOTTOMLEFT", talentIndexFrame, "TOPLEFT", 0, -4)
+        talentIndexFrame.levelHeader:SetPoint("BOTTOMLEFT", talentIndexFrame,
+                                              "TOPLEFT", 0, -4)
     else
         -- talentIndexFrame.levelHeader.text:SetFont(addon.font, 8, "OUTLINE")
-        talentIndexFrame.levelHeader:SetPoint("BOTTOMLEFT", talentIndexFrame, "TOPLEFT", -2 * #sorted_levels, -4)
+        talentIndexFrame.levelHeader:SetPoint("BOTTOMLEFT", talentIndexFrame,
+                                              "TOPLEFT", -2 * #sorted_levels, -4)
     end
 
     -- No changes, prevent uneeded UI calls
     if talentIndexFrame.levelHeader.text:GetText() == newText then return end
 
     talentIndexFrame.levelHeader.text:SetText(newText)
-    talentIndexFrame.levelHeader:SetSize(talentIndexFrame.levelHeader.text:GetStringWidth() + 10, 17)
+    talentIndexFrame.levelHeader:SetSize(
+        talentIndexFrame.levelHeader.text:GetStringWidth() + 10, 17)
 end
 
 -- https://www.wowhead.com/guide=cataclysm&mastery#talents
 local cataTalentLevels = {
-    10, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65,
-    67, 69, 71, 73, 75, 77, 79, 81, 82, 83, 84, 85
+    10, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45,
+    47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 82,
+    83, 84, 85
 }
 
-local function lookupTalentLevel(nextTalentStepIndex) return cataTalentLevels[nextTalentStepIndex] end
+local function lookupTalentLevel(nextTalentStepIndex)
+    return cataTalentLevels[nextTalentStepIndex]
+end
 
 function addon.talents.cata:DrawTalents(guide)
     guide = guide or self:GetCurrentGuide()
@@ -1073,14 +1228,16 @@ function addon.talents.cata:DrawTalents(guide)
     local remainingPoints, levelStep, talentIndex
 
     if GetUnspentTalentPoints then
-        remainingPoints = GetUnspentTalentPoints() - GetGroupPreviewTalentPointsSpent()
+        remainingPoints = GetUnspentTalentPoints() -
+                              GetGroupPreviewTalentPointsSpent()
     else
         remainingPoints = UnitCharacterPoints("player")
     end
 
     local playerLevel = UnitLevel("player")
 
-    local advancedWarning = playerLevel + addon.settings.profile.upcomingTalentCount
+    local advancedWarning = playerLevel +
+                                addon.settings.profile.upcomingTalentCount
 
     -- TODO cache data if unchanged
     local talentInfo, levelLookup, levelStepIndex
@@ -1095,18 +1252,22 @@ function addon.talents.cata:DrawTalents(guide)
             for _, element in ipairs(levelStep.elements) do
                 for _, talentData in ipairs(element.talent) do
 
-                    talentIndex = indexLookup['player'][talentData.tab][talentData.tier][talentData.column]
+                    talentIndex =
+                        indexLookup['player'][talentData.tab][talentData.tier][talentData.column]
 
                     if talentTooltips.cataPlan[talentData.tab][talentIndex] then
-                        talentInfo = talentTooltips.cataPlan[talentData.tab][talentIndex]
+                        talentInfo =
+                            talentTooltips.cataPlan[talentData.tab][talentIndex]
                     else
                         talentInfo = {
                             levels = {},
                             talentData = talentData,
-                            tooltipTextHeader = fmt("%s - %s", addon.title, guide.name)
+                            tooltipTextHeader = fmt("%s - %s", addon.title,
+                                                    guide.name)
                         }
 
-                        talentTooltips.cataPlan[talentData.tab][talentIndex] = talentInfo
+                        talentTooltips.cataPlan[talentData.tab][talentIndex] =
+                            talentInfo
                     end
 
                     levelLookup = lookupTalentLevel(levelStepIndex)
@@ -1120,9 +1281,11 @@ function addon.talents.cata:DrawTalents(guide)
                     end
 
                     if not talentInfo.talentIndexFrameName then
-                        talentInfo.talentIndexFrameName = "PlayerTalentFramePanel" .. talentData.tab .. "Talent" ..
-                                                              talentIndex
-                        talentInfo.talentIndexFrame = _G[talentInfo.talentIndexFrameName]
+                        talentInfo.talentIndexFrameName =
+                            "PlayerTalentFramePanel" .. talentData.tab ..
+                                "Talent" .. talentIndex
+                        talentInfo.talentIndexFrame =
+                            _G[talentInfo.talentIndexFrameName]
 
                         -- Add reverse lookup for tooltip updateFunc logic
                         talentInfo.talentIndexFrame.RXP = talentInfo
@@ -1147,7 +1310,9 @@ function addon.talents.cata:DrawTalents(guide)
 end
 
 function addon.talents.cata.CleanupTalentPlan()
-    if _G.PlayerTalentFrameResetButton_OnClick then _G.PlayerTalentFrameResetButton_OnClick() end
+    if _G.PlayerTalentFrameResetButton_OnClick then
+        _G.PlayerTalentFrameResetButton_OnClick()
+    end
 
     local f
 
@@ -1158,7 +1323,9 @@ function addon.talents.cata.CleanupTalentPlan()
             if f and f.levelHeader and f.levelHeader:IsShown() then
                 f.levelHeader:Hide()
 
-                if f.levelHeader.text then f.levelHeader.text:SetText(nil) end
+                if f.levelHeader.text then
+                    f.levelHeader.text:SetText(nil)
+                end
             end
 
             wipe(tInfo.levels)

--- a/Talents.lua
+++ b/Talents.lua
@@ -1067,10 +1067,6 @@ function addon.talents:ProcessTalents(validate)
                     if result then
                         -- Avoid blocking on user action if talent exists in any optional blocks
                         optionalLearned = optionalName
-                        addon.comms.PrettyPrint("%s - (%s) %s (%s %d)",
-                                            _G.TRADE_SKILLS_LEARNED_TAB,
-                                            _G.COMMUNITIES_CHANNEL_DESCRIPTION_INSTRUCTIONS,
-                                            optionalName)
                     else
                         -- Specific optional .talent not learned
                         tinsert(optionalNotLearned, optionalName)

--- a/Talents.lua
+++ b/Talents.lua
@@ -723,7 +723,7 @@ function addon.talents:DrawTalents()
     wipe(activeIndices)
     wipe(levelsForIndex)
 
-    local newHightlightTexture
+    local newHightlightTexture, tooltipPrefix
     RXPD = {}
     -- Create highlight frames and set data objects for later processing
     for upcomingTalent = (playerLevel + 1 - remainingPoints), advancedWarning do
@@ -731,6 +731,7 @@ function addon.talents:DrawTalents()
         levelStep = guide.steps[upcomingTalent - guide.minLevel + 1]
 
         if levelStep then
+            tooltipPrefix = levelStep.optional and _G.COMMUNITIES_CHANNEL_DESCRIPTION_INSTRUCTIONS or _G.TRADE_SKILLS_LEARNED_TAB
             RXPD[upcomingTalent - guide.minLevel + 1] = levelStep
             for _, element in ipairs(levelStep.elements) do
                 for _, talentData in ipairs(element.talent) do
@@ -744,7 +745,7 @@ function addon.talents:DrawTalents()
                                                                fmt("\n%s - %s", addon.title, guide.name)
 
                         talentTooltips.data[talentIndex] = fmt("%s\n%s%s: %s %d|r", talentTooltips.data[talentIndex],
-                                                               addon.colors.tooltip, _G.TRADE_SKILLS_LEARNED_TAB,
+                                                               addon.colors.tooltip, tooltipPrefix,
                                                                _G.LEVEL, upcomingTalent)
 
                         -- TODO Pre-seed tooltip to prevent delay

--- a/Talents.lua
+++ b/Talents.lua
@@ -337,9 +337,9 @@ function addon.talents:ParseGuide(text)
         elseif currentStep > 0 then -- Parse metadata tags first
 
             -- Parse function calls
-            parseSuccess = line:gsub("^%.(%S+)%s*(.*)", function(command, lineArgs)
-                -- print("Processing guide command", command, "with (", lineArgs, ")")
+            parseSuccess = line:gsub("^[%.#](%S+)%s*(.*)", function(command, lineArgs)
                 if self.functions[command] then
+                    -- print("Processing guide command", command, "with (", lineArgs, ")")
                     local element = self.functions[command](lineArgs)
 
                     if not element then
@@ -349,6 +349,8 @@ function addon.talents:ParseGuide(text)
                     end
 
                     tinsert(step.elements, element)
+                elseif command == "optional" then -- Allowlisted step flags, preserve typo handling
+                    step[command] = true
                 else
                     addon.error(L("Error parsing guide") .. " " .. (guide.name or 'Unknown') ..
                                     ": Invalid function call (." .. command .. ")\n" .. line)

--- a/Talents.lua
+++ b/Talents.lua
@@ -1085,7 +1085,7 @@ function addon.talents:ProcessTalents(validate)
 
         if step.optional and not optionalLearned then
             addon.comms:PopupNotification("RXPTalentsMissingOptional",
-                fmt("%s %s %s: %s\n%s\n%s",
+                fmt("%s %s %s: %s\n%s\n\n%s",
                     _G.ADDON_MISSING,
                     _G.OPTIONAL,
                     strlower(_G.TALENT_POINTS),


### PR DESCRIPTION
- [x] Drawing - "Optional" prefix on tooltip
- [x] Drawing - Optional levels listed above all talents for that level
- [x] Learning - Block if no optional talents selected
- [x] Update Classic Warrior for optional weapon specialization
- [x] Update TBC Warrior for optional weapon specialization
- [x] Address overlapping UI level range lists
- [x] Add TBC Rogue optional weapon specialization
- [x] Add Okay-only dialog function
- [x] Update version logic to use pretty name instead of TOC versions
- [x] Optimize Talent looping usage

