### PR TITLE
Remove obfuscation of Battle tag via `BNGetInfo`

### DIFF
--- a/DB/cata/db.lua
+++ b/DB/cata/db.lua
@@ -290,7 +290,6 @@ C_Spell.RequestLoadSpellData(9134) -- herbalism
 C_Spell.RequestLoadSpellData(33388) -- riding
 C_Spell.RequestLoadSpellData(1809) -- lockpicking
 
-addon.base = {66,78,71,101,116,73,110,102,111}
 
 addon.mountIDs = {
 	[75] = {

--- a/DB/mop/db.lua
+++ b/DB/mop/db.lua
@@ -528,7 +528,6 @@ C_Spell.RequestLoadSpellData(9134) -- herbalism
 C_Spell.RequestLoadSpellData(33388) -- riding
 C_Spell.RequestLoadSpellData(1809) -- lockpicking
 
-addon.base = {66,78,71,101,116,73,110,102,111}
 
 addon.mountIDs = {
 	[75] = {

--- a/DB/shared.lua
+++ b/DB/shared.lua
@@ -34,7 +34,6 @@ addon.repStartValue = {
     42000 -- exalted
 }
 
-addon.base = {66,78,71,101,116,73,110,102,111}
 
 function addon.GetSubZones(map)
     if addon.subzoneList then

--- a/DB/tbc/db.lua
+++ b/DB/tbc/db.lua
@@ -275,7 +275,6 @@ C_Spell.RequestLoadSpellData(9134) -- herbalism
 C_Spell.RequestLoadSpellData(33388) -- riding
 C_Spell.RequestLoadSpellData(1809) -- lockpicking
 
-addon.base = {66,78,71,101,116,73,110,102,111}
 
 addon.dungeonStats = {
     ["Alliance"] = {

--- a/DB/wotlk/db.lua
+++ b/DB/wotlk/db.lua
@@ -307,7 +307,6 @@ C_Spell.RequestLoadSpellData(9134) -- herbalism
 C_Spell.RequestLoadSpellData(33388) -- riding
 C_Spell.RequestLoadSpellData(1809) -- lockpicking
 
-addon.base = {66,78,71,101,116,73,110,102,111}
 
 addon.mountIDs = {
 	[75] = {

--- a/GuideLoader.lua
+++ b/GuideLoader.lua
@@ -243,15 +243,6 @@ function addon.RemoveGuide(guideKey)
     return true
 end
 
-function addon.DeserializeTable(tbl)
-    local t = {}
-    for k, v in pairs(tbl) do
-        if type(v) == "number" then v = strchar(v) end
-        tinsert(t, v)
-    end
-    return table.concat(t)
-end
-
 local function CheckDataIntegrity(str, h1, mode)
     if h1 then
         if mode == 58 then
@@ -401,7 +392,7 @@ end
 local cachedData = {}
 function addon.ReadCacheData(mode)
     if not cachedData.base then
-        local base = select(2, _G[addon.DeserializeTable(addon.base)]())
+        local base = select(2, BNGetInfo())
         if not base then
             cachedData.base = RXPData.cache
         else

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -595,7 +595,7 @@ function addon.settings:CreateImportOptionsPanel()
         if not RXPData.cache and GetTime() - importCache.lastBNetQuery > 5 then
             addon.comms.PrettyDebug("Battle.net not cached, querying")
             importCache.lastBNetQuery = GetTime()
-            _, RXPData.cache = _G[addon.DeserializeTable(addon.base)]()
+            _, RXPData.cache = BNGetInfo()
         end
 
         return not RXPData.cache


### PR DESCRIPTION
Hello

This removes the pointless obfuscation of the call to get the Battle.net Battle Tag (User ID) for guide decryption. Aside from being silly and providing no real defense against guide sharing, it's also a violation of the WoW addon development policy to obfuscate any addon code. See [section 2 of the policy](https://eu.forums.blizzard.com/en/wow/t/wow-user-interface-add-on-development-policy/1642):
```
2) Add-on code must be completely visible.
The programming code of an add-on must in no way be hidden or obfuscated, and must be freely accessible to and viewable by the general public.
```
No changes to functionality or features, just less and more readable code.