### PR TITLE
Fix HCSpellList lookup for hardcore trainer skip

### DIFF
--- a/DB/classic/spells-sod.lua
+++ b/DB/classic/spells-sod.lua
@@ -6,12 +6,13 @@ C_Spell.RequestLoadSpellData(2368) -- herbalism
 
 -- Spells not used in hardcore:
 addon.HCSpellList = {
-    20752, -- create soulstone r2
-    20755, -- create soulstone r3
-    20756, -- create soulstone r4
-    20757, -- create soulstone r5
-    1949, -- hellfire r1
-    20608 -- reincarnation
+    [693] = true, -- soulstone r1
+    [20752] = true, -- create soulstone r2
+    [20755] = true, -- create soulstone r3
+    [20756] = true, -- create soulstone r4
+    [20757] = true, -- create soulstone r5
+    [1949] = true, -- hellfire r1
+    [20608] = true -- reincarnation
 }
 
 local s = {}

--- a/DB/classic/spells.lua
+++ b/DB/classic/spells.lua
@@ -6,12 +6,13 @@ C_Spell.RequestLoadSpellData(2368) -- herbalism
 
 -- Spells not used in hardcore:
 addon.HCSpellList = {
-    20752, -- create soulstone r2
-    20755, -- create soulstone r3
-    20756, -- create soulstone r4
-    20757, -- create soulstone r5
-    1949, -- hellfire r1
-    20608 -- reincarnation
+    [693] = true, -- soulstone r1
+    [20752] = true, -- create soulstone r2
+    [20755] = true, -- create soulstone r3
+    [20756] = true, -- create soulstone r4
+    [20757] = true, -- create soulstone r5
+    [1949] = true, -- hellfire r1
+    [20608] = true -- reincarnation
 }
 
 local s = {}


### PR DESCRIPTION
## Summary

- Convert `HCSpellList` from array syntax to keyed `[spellId] = true` entries so `HCSpellList[spellId]` lookups in `ProcessSpells` actually work
- Add Soulstone rank 1 (`693`) to the hardcore skip list (trained at level 18)

## Context

v4.10.13 (`c50dc0b`) switched hardcore trainer logic to `C_GameRules.IsHardcoreActive()`, but `HCSpellList` in `DB/classic/spells.lua` was unchanged. Entries like `20752,` are stored at numeric indices `1..n`, not as keys — so `HCSpellList[20752]` was always `nil` and listed spells were still auto-purchased on HC servers.

## Test plan

- [ ] On a Hardcore Classic Era warlock with trainer automation enabled, open a class trainer at level 18+ and confirm Soulstone (`693`) is not auto-bought
- [ ] At level 30+, confirm Create Soulstone ranks (`20752`+) are not auto-bought
- [ ] On a non-HC server (or with trainer automation off), confirm normal trainer behavior is unchanged
- [ ] Confirm Hellfire / Reincarnation skips still work on HC