### PR TITLE
Fix .buy limited stock bug

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -5498,9 +5498,14 @@ function addon.functions.buy(self, ...)
             local link = GetMerchantItemLink(i)
             local itemID = link and tonumber(link:match("item:(%d+)"))
             if itemID then
-                local name, _, _, quantity = GetMerchantItemInfo(i)
+                -- numAvailable is -1 when unlimited and at least 0 until window is closed (if present)
+                local name, _, _, quantity, numAvailable = GetMerchantItemInfo(i)
 
                 if itemID == id or name == id then
+                    if numAvailable ~= -1 then
+                        total = math.min(total, numAvailable)
+                    end
+
                     addon.comms.PrettyPrint("Buying " .. name .. " x" .. total) -- ok
                     local stack = select(8, GetItemInfo(id))
                     if quantity then


### PR DESCRIPTION
If we tried to buy more than is available of something, nothing happens and we receive an error: "That item is currently sold out."

Now it will cap the total buy quantity to numAvailable returned from GetMerchantItemInfo().