### PR TITLE
OnLoad optimizations - part 1

### DIFF
--- a/GuideLoader.lua
+++ b/GuideLoader.lua
@@ -553,22 +553,28 @@ function addon.ProcessInputBuffer(workerFrame)
     return false
 end
 
-local embeddedGuidesLoaded
+local embeddedGuidesLoaded, embeddedGuideIndex
 function addon.LoadEmbeddedGuides()
     if not addon.db then
         error('Initialization error, db not set')
         return
     end
+
     if embeddedGuidesLoaded then
         return
     else
         embeddedGuidesLoaded = true
     end
+
     --A1 = GetTimePreciseSec()
     if RXPCData.guideDisabled[0] ~= #embeddedGuides then
         RXPCData.guideDisabled = {[0] = #embeddedGuides}
     end
-    for n, guideData in ipairs(embeddedGuides) do
+
+    local guideData
+    for n = embeddedGuideIndex or 1, #embeddedGuides do
+        guideData = embeddedGuides[n]
+
         if guideData.cache then
             addon.ImportGuide(guideData.groupOrContent, guideData.text,
                               guideData.defaultFor, true)
@@ -667,8 +673,15 @@ function addon.LoadEmbeddedGuides()
                 addon.AddGuide(guide)
             end
         end
+        embeddedGuideIndex = n + 1
+        if embeddedGuideIndex <= #embeddedGuides then
+            embeddedGuidesLoaded = false
+            C_Timer.After(0, addon.LoadEmbeddedGuides)
+            return
+        end
     end
 
+    embeddedGuideIndex = nil
     if addon.addonLoaded then
         embeddedGuides = nil
     else
@@ -677,6 +690,10 @@ function addon.LoadEmbeddedGuides()
 
     --A1 = GetTimePreciseSec() - A1
     addon.RXPFrame.GenerateMenuTable()
+    if addon.addonLoaded then
+        addon:LoadGuide(addon.GetGuideTable(RXPCData.currentGuideGroup,
+                                             RXPCData.currentGuideName), true)
+    end
 end
 
 function addon.BuildGuideKey(arg1,arg2,arg3)

--- a/Talents.lua
+++ b/Talents.lua
@@ -27,6 +27,7 @@ local L = addon.locale.Get
 addon.talents = addon:NewModule("Talents", "AceEvent-3.0")
 addon.talents.functions = {}
 addon.talents.guides = {}
+addon.talents.pendingGuides = {}
 addon.talents.maxLevel = GetMaxPlayerLevel()
 
 addon.talents.petGuides = {
@@ -196,7 +197,9 @@ local function buildTalentGuidesMenu()
     return menu
 end
 
-function addon.talents:IsSupported() return self.guides and next(self.guides) ~= nil and compatible end
+function addon.talents:IsSupported()
+    return compatible and (next(self.guides) ~= nil or self.pendingGuides and #self.pendingGuides > 0)
+end
 
 function addon.talents:Setup()
     if not addon.settings.profile.enableTalentGuides then return end
@@ -204,8 +207,9 @@ function addon.talents:Setup()
     if not self:IsSupported() then return end
 
     self:RegisterEvent("ADDON_LOADED")
-
-    self:UpdateSelectedGuide(RXPCData.activeTalentGuide)
+    if _G.PlayerTalentFrame then
+        self:ADDON_LOADED(nil, "Blizzard_TalentUI")
+    end
 
     if tonumber(GetCVar("previewTalents")) == 0 and addon.game == "WOTLK" and addon.settings.profile.previewTalents then
         -- Talents are enabled in RXP, so match client
@@ -217,13 +221,20 @@ end
 function addon.talents:ADDON_LOADED(_, loadedAddon)
     -- Talent frame/globals get loaded on demand when it's first opened
     if loadedAddon == "Blizzard_TalentUI" then
-        _G.PlayerTalentFrame:HookScript("OnShow", function() addon.talents:HookUI() end)
+        _G.PlayerTalentFrame:HookScript("OnShow", function()
+            self:LoadGuides()
+            self:HookUI()
+        end)
 
         _G.PlayerTalentFrame:HookScript("OnUpdate", function() self:DrawTalents() end)
 
         PlayerTalentFrame = _G.PlayerTalentFrame
 
         self:BuildIndexLookup()
+        if PlayerTalentFrame:IsShown() then
+            self:LoadGuides()
+            self:HookUI()
+        end
     elseif loadedAddon == "Talented" then
         compatible = false
         addon.comms.PrettyPrint(L("Talented detected, please disable for talent guide functionality")) -- TODO locale
@@ -344,7 +355,7 @@ function addon.talents:HookUI()
     end
 end
 
-function addon.talents.RegisterGuide(text)
+local function registerGuide(text)
     local guide = addon.talents:ParseGuide(text)
 
     if not (guide and guide.key) then return end
@@ -355,6 +366,24 @@ function addon.talents.RegisterGuide(text)
     end
 
     addon.talents.guides[guide.key] = guide
+end
+
+function addon.talents.RegisterGuide(text)
+    if addon.talents.pendingGuides then
+        tinsert(addon.talents.pendingGuides, text)
+    else
+        registerGuide(text)
+    end
+end
+
+function addon.talents:LoadGuides()
+    if not self.pendingGuides then return end
+
+    for _, text in ipairs(self.pendingGuides) do
+        registerGuide(text)
+    end
+    self.pendingGuides = nil
+    self:UpdateSelectedGuide(RXPCData.activeTalentGuide)
 end
 
 function addon.talents:ParseGuide(text)


### PR DESCRIPTION
- Delay Talent loading until Blizzard Talents frame is loaded, rather than at sequentially at addon startup
- Limit guide loading to one-per-frame